### PR TITLE
Info outputs

### DIFF
--- a/lib/info.js
+++ b/lib/info.js
@@ -5,16 +5,23 @@ const AWS = require('aws-sdk');
 
 class Info {
     static help() {
-        console.log();
-        console.log('usage deploy info');
-        console.log();
-        console.error('Get info about a specific stack in the current repo');
         console.log()
+        console.log('Get info about a specific stack in the current repo');
+        console.log();
+        console.log('Usage: deploy info [--output] [--help]');
+        console.log();
+        console.log('Options:')
+        console.log('  --outputs        print stack outputs in a table');
+        console.log('  --help           show this help message');
+        console.log();
     }
 
     static main(creds, argv) {
         argv = minimist(argv, {
-            boolean: ['output']
+            boolean: ['output'],
+            alias: {
+                output: 'outputs'
+            }
         });
 
         const cloudformation = new AWS.CloudFormation({

--- a/lib/info.js
+++ b/lib/info.js
@@ -1,0 +1,51 @@
+const Table = require('cli-table');
+const minimist = require('minimist');
+const cf = require('@mapbox/cfn-config');
+const AWS = require('aws-sdk');
+
+class Info {
+    static help() {
+        console.log();
+        console.log('usage deploy info');
+        console.log();
+        console.error('Get info about a specific stack in the current repo');
+        console.log()
+    }
+
+    static main(creds, argv) {
+        argv = minimist(argv, {
+            boolean: ['output']
+        });
+
+        const cloudformation = new AWS.CloudFormation({
+            region: creds.region
+        });
+
+        if (!argv._[3]) return console.error(`Stack name required: run deploy info --help`);
+
+        const stack = argv._[3];
+
+        cf.lookup.info(`${creds.repo}-${stack}`, creds.region, true, false, (err, info) => {
+            if (err) throw err;
+
+            if (argv.output) {
+                const table = new Table({
+                    head: ['Name', 'Value']
+                });
+
+                for (const output of Object.keys(info.Outputs)) {
+                    table.push([output, info.Outputs[output]]);
+                }
+
+                console.log();
+                console.log('Outputs:')
+                console.log(table.toString());
+                console.log();
+            } else {
+                console.log(JSON.stringify(info, null, 4));
+            }
+        });
+    }
+}
+
+module.exports = Info;

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@mapbox/cfn-config": "^2.22.0",
     "@mapbox/cloudfriend": "^4.0.0",
     "aws-sdk": "^2.631.0",
+    "cli-table": "^0.3.1",
     "d3-queue": "^3.0.7",
     "handlebars": "^4.7.3",
     "minimist": "^1.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -178,6 +178,13 @@ cli-cursor@^2.1.0:
   dependencies:
     restore-cursor "^2.0.0"
 
+cli-table@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/cli-table/-/cli-table-0.3.1.tgz#f53b05266a8b1a0b934b3d0821e6e2dc5914ae23"
+  integrity sha1-9TsFJmqLGguTSz0IIebi3FkUriM=
+  dependencies:
+    colors "1.0.3"
+
 cli-width@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.0.tgz#ff19ede8a9a5e579324147b0c11f0fbcbabed639"
@@ -200,7 +207,7 @@ color-name@1.1.3:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
 
-colors@1.0.x:
+colors@1.0.3, colors@1.0.x:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.0.3.tgz#0433f44d809680fdeb60ed260f1b0c262e82a40b"
   integrity sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=


### PR DESCRIPTION
By default the `deploy info` command simply returns a JSON document.

I often find myself running

```
deploy info <stack> | jq .Outputs
```

So now you can run

```
deploy info <stack> --outputs
```

and get a nice table

