### PR TITLE
HTTP Origin Owners

### DIFF
--- a/lib/creds.js
+++ b/lib/creds.js
@@ -51,6 +51,7 @@ class Credentials {
     constructor (argv, opts) {
         this.user = Credentials.gituser();
         this.owner = Credentials.gitowner();
+
         this.repo = Credentials.gitrepo();
         this.sha = Credentials.gitsha();
 
@@ -266,11 +267,20 @@ class Credentials {
 
         const owner = String(git.stdout).replace(/\n/g, '');
 
-        if (!owner.includes('git@github.com')) throw new Error('only origins of format: git@github.com are supported');
+        if (owner.includes('git@github.com')) {
+            return owner
+                .replace(/.*git@github.com:/, '')
+                .replace(/\/.*/, '');
+        } else if (owner.includes('https://github.com')) {
+            const giturl = new URL(owner);
 
-        return owner
-            .replace(/.*git@github.com:/, '')
-            .replace(/\/.*/, '');
+            return giturl.pathname
+                .replace('.git', '')
+                .slice(1)
+                .replace(/\/.*/, '')
+        } else {
+            throw new Error('only origins of format: git@github.com are supported');
+        }
     }
 
     /**

--- a/lib/creds.js
+++ b/lib/creds.js
@@ -277,7 +277,7 @@ class Credentials {
             return giturl.pathname
                 .replace('.git', '')
                 .slice(1)
-                .replace(/\/.*/, '')
+                .replace(/\/.*/, '');
         } else {
             throw new Error('only origins of format: git@github.com are supported');
         }

--- a/lib/init.js
+++ b/lib/init.js
@@ -94,7 +94,7 @@ class Init {
 
             const full = Bucket + creds.accountId + '-' + creds.region;
             try {
-                const bucket = await s3.headBucket({
+                await s3.headBucket({
                     Bucket: full,
                     ExpectedBucketOwner: creds.accountId
                 }).promise();


### PR DESCRIPTION
### Context

Deploy currently does not have the ability to parse Github Owner/Org information from https origins. At this time ssh/git origins are the only supported type.

This PR implements parsing github org information from an HTTPS origin string

Ref: https://github.com/tnc-ca-geo/shp2json/issues/10