### PR TITLE
Update to cloudfriend 5.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
     "name": "@openaddresses/deploy",
-    "version": "4.2.0",
+    "version": "4.3.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@openaddresses/deploy",
-            "version": "4.2.0",
+            "version": "4.3.0",
             "license": "MIT",
             "dependencies": {
-                "@mapbox/cloudfriend": "^5.0.2",
+                "@mapbox/cloudfriend": "^5.1.0",
                 "@octokit/rest": "^18.0.4",
                 "@openaddresses/cfn-config": "5.0.0",
                 "ajv": "^8.6.3",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         "deploy": "cli.js"
     },
     "dependencies": {
-        "@mapbox/cloudfriend": "^5.0.2",
+        "@mapbox/cloudfriend": "^5.1.0",
         "@octokit/rest": "^18.0.4",
         "@openaddresses/cfn-config": "5.0.0",
         "ajv": "^8.6.3",


### PR DESCRIPTION
This PR bumps the `cloudfriend` dependency to the most recent version.

(Context: I'm looking to use `deploy` in an upcoming project, and hoping to avoid duplicate versions of cloudfriend being installed in the environment I'm deploying from, but need the fix in https://github.com/mapbox/cloudfriend/pull/127 , which is only in 5.1.0. Doesn't look like there are any other changes between 5.0.x and 5.1.x, so this should be an otherwise-inconsequential change.)

cc @ingalls 