### PR TITLE
Remove AccountID

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -120,8 +120,8 @@ async function main() {
         const cf = new cfn.Commands({
             name: creds.repo,
             region: creds.region,
-            configBucket: `cfn-config-active-${creds.accountId}-${creds.region}`,
-            templateBucket: `cfn-config-templates-${creds.accountId}-${creds.region}`
+            configBucket: `cfn-config-active-${await creds.accountId()}-${creds.region}`,
+            templateBucket: `cfn-config-templates-${await creds.accountId()}-${creds.region}`
         });
 
         let template = await friend.build(creds.template);
@@ -196,7 +196,7 @@ async function main() {
                 template: false
             });
 
-            mode[command].main(creds, process.argv);
+            await mode[command].main(creds, process.argv);
         }
     } else {
         console.error('Subcommand not found!');

--- a/data/rc_schema.json
+++ b/data/rc_schema.json
@@ -3,9 +3,6 @@
     "patternProperties": {
         ".*": {
             "type": "object",
-            "required": [
-                "accountId"
-            ],
             "additionalProperties": false,
             "properties": {
                 "region": {
@@ -15,7 +12,7 @@
                 },
                 "accountId": {
                     "type": "string",
-                    "description": "AWS Account ID"
+                    "description": "[deprecated] AWS Account ID"
                 },
                 "github": {
                     "type" :"string",

--- a/lib/creds.js
+++ b/lib/creds.js
@@ -12,7 +12,6 @@ const ajv = new AJV({
 // when loaded from a .deployrc.json file
 const PROFILE_KEYS = [
     'region',
-    'accountId',
     'accessKeyId',
     'secretAccessKey',
     'github'
@@ -66,9 +65,9 @@ export default class Credentials {
         this.tags = [];
 
         this.region = 'us-east-1';
-        this.accountId = false;
         this.accessKeyId = false;
         this.secretAccessKey = false;
+        this.accountId = false;
 
         this.github = false;
 
@@ -295,5 +294,16 @@ export default class Credentials {
         if (!git.stdout) return (new Error('Is this a git repo? Could not determine GitSha'));
         return String(git.stdout).replace(/\n/g, '');
 
+    }
+
+    async accountId() {
+        if (this.accountId) return this.accountId;
+
+        const STS = new AWS.STS();
+
+        const account = await STS.getCallerIdentity().promise();
+        this.accountId = account.Account;
+
+        return this.accountId;
     }
 }

--- a/lib/env.js
+++ b/lib/env.js
@@ -18,8 +18,8 @@ export default class Env {
      *
      * @param {Credentials} creds Credentials
      */
-    static main(creds) {
-        console.log(`export AWS_ACCOUNT_ID=${creds.accountId}`);
+    static async main(creds) {
+        console.log(`export AWS_ACCOUNT_ID=${await creds.accountId()}`);
         console.log(`export AWS_DEFAULT_REGION=${creds.region}`);
         console.log(`export AWS_ACCESS_KEY_ID=${creds.accessKeyId}`);
         console.log(`export AWS_SECRET_ACCESS_KEY=${creds.secretAccessKey}`);

--- a/lib/init.js
+++ b/lib/init.js
@@ -36,10 +36,6 @@ export default class Init {
             type: 'string',
             required: true,
             default: 'us-east-1'
-        },{
-            name: 'accountId',
-            type: 'string',
-            required: true
         }]);
 
         const awscreds = new AWS.SharedIniFileCredentials({
@@ -71,7 +67,6 @@ export default class Init {
 
         creds[argv['profile-name']] = {
             region: argv.region,
-            accountId: argv.accountId,
             accessKeyId: argv.accessKeyId,
             secretAccessKey: argv.secretAccessKey
         };
@@ -86,13 +81,13 @@ export default class Init {
         const s3 = new AWS.S3({ region: creds.region });
 
         for (const Bucket of ['cfn-config-templates-', 'cfn-config-active-']) {
-            if (!creds.accountId || !creds.region) continue;
+            if (!creds.region) continue;
 
-            const full = Bucket + creds.accountId + '-' + creds.region;
+            const full = Bucket + await creds.accountId() + '-' + creds.region;
             try {
                 await s3.headBucket({
                     Bucket: full,
-                    ExpectedBucketOwner: creds.accountId
+                    ExpectedBucketOwner: await creds.accountId()
                 }).promise();
             } catch (err) {
                 if (err.code === 'NotFound') {


### PR DESCRIPTION
### Context

AccountID can be trivially looked up via the STS API. As such we should reduce the initial burden on the user for configuring a new AWS profile and look this value up dynamically.