### PR TITLE
minor typo in README -- deplyrc -> deployrc

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ to see a full list of options
 
 Note: The credentials file can be found in the `~/.deployrc.json` file
 
-# Global Config `~/.deplyrc.json`
+# Global Config `~/.deployrc.json`
 
 ## Required Tags
 


### PR DESCRIPTION
Fix minor typo in README

cc @ingalls 