### PR TITLE
Adds support for username prefixed remote origins

### DIFF
--- a/lib/git.js
+++ b/lib/git.js
@@ -56,7 +56,7 @@ export default class Git {
             return owner
                 .replace(/.*git@github.com:/, '')
                 .replace(/\/.*/, '');
-        } else if (owner.includes('https://github.com')) {
+        } else if (owner.match('https://.*github.com')) {
             const giturl = new URL(owner);
 
             return giturl.pathname


### PR DESCRIPTION

## The issue
If someone has multiple git accounts, their git repo might have a remote origin url containing that particular username associated with that repo:

i.e. https://ingalls@github.com/openaddresses/deploy

https://stackoverflow.com/questions/68343369/github-difference-between-https-usernamegithub-com-and-https-github-com-f

which is not a format that current is supported when parsing the git remote url. We get failures of the form: 

```
$ deploy list
Command failure: only origins of format: git@github.com or https://github.com are supported
```

## The change
In this PR I've made a slight modification to the parsing logic to allow for this case.


## The deets
Here's some validation I did adhoc to demonstrate and resolve the issue:

Here's the "happy case"...
```
$ const git = "https://github.com/owner/repo.git";
$ const giturl = new URL(git);
$ giturl.pathname.replace('.git', '').slice(1).replace(/\/.*/, '')
'owner'
```

Here's the problem case with the user name, you can see the parsing logic itself actually works fine...
```
$ const git = "https://user@github.com/owner/repo.git";
$ const giturl = new URL(git);
$ giturl.pathname.replace('.git', '').slice(1).replace(/\/.*/, '')
'owner'
```

But the logic to enter this case is not inclusive enough:
```
$ git.includes('https://github.com')
false
```

So, I've modified it to be this:
```
$ !!git.match('https://.*github.com')
true
```

Which includes the original happy case as well:
```
$ const git = "https://github.com/owner/repo.git";
$ !!git.match('https://.*github.com')
true
```

And still rejects improper urls:
```
$ const git = "https://badgithuburl.com"
$ !!git.match('https://.*github.com')
false
```