### PR TITLE
AWS SDK V3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ## Version History
 
+### v7.7.0
+- :arrow_up: Remove top-level use of aws-sdk
+- :tada: Add support for GovCloud S3 Config Buckets
+
 ### v7.6.0
 
 - :bug: Include region in STS call to work in GovCloud

--- a/cli.js
+++ b/cli.js
@@ -46,7 +46,7 @@ async function main() {
             process.exit(1);
         }
 
-        const creds = new Credentials(argv, {});
+        const creds = await Credentials.generate(argv, {});
         const gh = new GH(creds);
 
         const cfn = CFN.preauth(creds);
@@ -159,7 +159,7 @@ async function main() {
             mode[command].main(process.argv);
         } else {
             try {
-                const creds = new Credentials(argv, {
+                const creds = await Credentials.generate(argv, {
                     template: false
                 });
 

--- a/cli.js
+++ b/cli.js
@@ -49,7 +49,7 @@ async function main() {
         const creds = await Credentials.generate(argv, {});
         const gh = new GH(creds);
 
-        const cfn = CFN.preauth(creds);
+        const cfn = CFN.preauth({ ...creds, ...creds.aws });
 
         // Ensure config & template buckets exist
         await mode.init.bucket(creds);

--- a/lib/artifacts/docker.js
+++ b/lib/artifacts/docker.js
@@ -1,4 +1,4 @@
-import AWS from 'aws-sdk';
+import { ECRClient, BatchGetImageCommand } from '@aws-sdk/client-ecr';
 import path from 'path';
 import fs from 'fs';
 import Handlebars from 'handlebars';
@@ -54,7 +54,8 @@ export default async function check(creds) {
 
 function single(creds, image) {
     return new Promise((resolve, reject) => {
-        const ecr = new AWS.ECR({
+        const ecr = new ECRClient({
+            credentials: creds.aws,
             region: creds.region
         });
 
@@ -71,12 +72,12 @@ function single(creds, image) {
 
         checkecr();
 
-        function checkecr() {
-            ecr.batchGetImage({
-                imageIds: [{ imageTag: image.split(':')[1] }],
-                repositoryName: image.split(':')[0]
-            }, (err, data) => {
-                if (err) return reject(err);
+        async function checkecr() {
+            try {
+                const data = await ecr.send(new BatchGetImageCommand({
+                    imageIds: [{ imageTag: image.split(':')[1] }],
+                    repositoryName: image.split(':')[0]
+                }));
 
                 if (data && data.images.length) {
                     console.log(`Found Docker Image: AWS::ECR:${image}`)
@@ -88,7 +89,9 @@ function single(creds, image) {
                 } else {
                     return reject(new Error(`No image found for: ${image}`));
                 }
-            });
+            } catch (err) {
+                return reject(err);
+            }
         }
     });
 }

--- a/lib/artifacts/lambda.js
+++ b/lib/artifacts/lambda.js
@@ -1,4 +1,4 @@
-import AWS from 'aws-sdk';
+import { S3Client, HeadObjectCommand } from '@aws-sdk/client-s3';
 import path from 'path';
 import fs from 'fs';
 import Handlebars from 'handlebars';
@@ -42,7 +42,8 @@ export default async function check(creds) {
 
 function single(creds, lambda, cb) {
     return new Promise((resolve, reject) => {
-        const s3 = new AWS.S3({
+        const s3 = new S3Client({
+            credentials: creds.aws,
             region: creds.region
         });
 
@@ -55,24 +56,28 @@ function single(creds, lambda, cb) {
 
         checks3();
 
-        function checks3() {
-            s3.headObject({
-                Bucket: lambda.split('/')[0],
-                Key: lambda.split('/').splice(1).join('/')
-            }, (err, data) => {
-                if (err && err.code === 'NotFound' && retries[lambda] < MAX_RETRIES) {
-                    if (retries[lambda] === 0) console.log(`Waiting for Lambda: ${lambda}`);
-                    retries[lambda] += 1;
-                    setTimeout(checks3, 5000);
-                } else if (err && err.code !== 'NotFound') {
-                    return reject(err);
-                } else if (data && data.ContentLength) {
+        async function checks3() {
+            try {
+                const data = await s3.send(new HeadObjectCommand({
+                    Bucket: lambda.split('/')[0],
+                    Key: lambda.split('/').splice(1).join('/')
+                }));
+
+                if (data && data.ContentLength) {
                     console.log(`Found Lambda: ${lambda}`)
                     return resolve(lambda);
                 } else {
                     return reject(new Error(`No lambda found for: ${lambda}`));
                 }
-            });
+            } catch (err) {
+                if (err && err.code === 'NotFound' && retries[lambda] < MAX_RETRIES) {
+                    if (retries[lambda] === 0) console.log(`Waiting for Lambda: ${lambda}`);
+                    retries[lambda] += 1;
+                    setTimeout(checks3, 5000);
+                } else {
+                    return reject(err);
+                }
+            }
         }
     });
 }

--- a/lib/creds.js
+++ b/lib/creds.js
@@ -1,8 +1,9 @@
 import fs from 'fs';
 import path from 'path';
-import AWS from 'aws-sdk';
 import Git from './git.js';
 import AJV from 'ajv';
+import { fromIni } from '@aws-sdk/credential-providers';
+import { STSClient, GetCallerIdentityCommand } from '@aws-sdk/client-sts';
 
 const ajv = new AJV({
     allErrors: true
@@ -10,12 +11,7 @@ const ajv = new AJV({
 
 // Only these keys are allowed to overwrite Credentials keys
 // when loaded from a .deployrc.json file
-const PROFILE_KEYS = [
-    'region',
-    'accessKeyId',
-    'secretAccessKey',
-    'github'
-];
+const PROFILE_KEYS = [ 'region', 'github' ];
 
 /**
  * Store all credentials required for deploy functionality
@@ -40,38 +36,38 @@ const PROFILE_KEYS = [
  * @prop {Object} profiles
  * @prop {Array} tags
  * @prop {string} region
- * @prop {string} accessKeyId
- * @prop {string} secretAccessKey
+ * @prop {object} aws AWS Credentials
  */
 export default class Credentials {
-    constructor (argv, opts) {
-        this.user = Git.user();
-        this.owner = Git.owner();
+    static async generate(argv, opts) {
+        const creds = new Credentials();
+        creds.user = Git.user();
+        creds.owner = Git.owner();
 
-        this.repo = Git.repo();
-        this.sha = Git.sha();
+        creds.repo = Git.repo();
+        creds.sha = Git.sha();
 
         // If GH deployment has been requested, store ID here
-        this.deployment = false;
+        creds.deployment = false;
 
-        this.name = false;
-        this.stack = (argv._[3] || '').replace(new RegExp(`^${this.repo}-`), '');
-        this.subname = false;
-        this.template = false;
-        this.profile = false;
-        this.dotdeploy = {};
-        this.profiles = {};
-        this.tags = [];
+        creds.name = false;
+        creds.stack = (argv._[3] || '').replace(new RegExp(`^${this.repo}-`), '');
+        creds.subname = false;
+        creds.template = false;
+        creds.profile = false;
+        creds.dotdeploy = {};
+        creds.profiles = {};
+        creds.tags = [];
 
-        this.region = 'us-east-1';
-        this.accessKeyId = false;
-        this.secretAccessKey = false;
+        creds.region = 'us-east-1';
+        creds.accessKeyId = false;
+        creds.secretAccessKey = false;
 
-        this.github = false;
+        creds.github = false;
 
         if (opts.template === undefined) opts.template = true;
 
-        this.dotdeploy = Credentials.dot_deploy();
+        creds.dotdeploy = Credentials.dot_deploy();
 
         let readcreds;
         try {
@@ -89,30 +85,30 @@ export default class Credentials {
 
         Object.keys(readcreds).forEach((key) => {
             if (readcreds[key] !== undefined) {
-                this.profiles[key] = readcreds[key];
+                creds.profiles[key] = readcreds[key];
             }
         });
 
         // CLI Params override config
         if (argv.region) {
-            this.region = argv.region;
-        } else if (this.dotdeploy.region) {
-            this.region = this.dotdeploy.region;
+            creds.region = argv.region;
+        } else if (creds.dotdeploy.region) {
+            creds.region = creds.dotdeploy.region;
         }
 
         if (opts.template && argv.template) {
-            this.subname = path.parse(argv.template).name.replace(/\.template/, '') + '-';
-            this.template = argv.template;
+            creds.subname = path.parse(argv.template).name.replace(/\.template/, '') + '-';
+            creds.template = argv.template;
         } else if (opts.template) {
-            this.subname = '';
+            creds.subname = '';
 
-            const cf_base = `${this.repo}.template`;
+            const cf_base = `${creds.repo}.template`;
             let cf_path = false;
             for (const file of fs.readdirSync(path.resolve('./cloudformation/'))) {
                 if (file.indexOf(cf_base) === -1) continue;
 
                 if (
-                    path.parse(file).name === this.repo + '.template'
+                    path.parse(file).name === creds.repo + '.template'
                     && (
                         path.parse(file).ext === '.js'
                         || path.parse(file).ext === '.json'
@@ -124,73 +120,63 @@ export default class Credentials {
             }
 
             if (!cf_path) {
-                throw new Error(`Could not find CF Template in cloudformation/${this.repo}.template.js(on)`);
+                throw new Error(`Could not find CF Template in cloudformation/${creds.repo}.template.js(on)`);
             }
 
-            this.template = cf_path;
+            creds.template = cf_path;
         }
 
-        if (this.dotdeploy.name) {
-            this.repo = this.dotdeploy.name;
+        if (creds.dotdeploy.name) {
+            creds.repo = creds.dotdeploy.name;
         }
 
         if (argv.profile) {
-            this.profile = argv.profile;
-        } else if (this.dotdeploy.profile) {
-            this.profile = this.dotdeploy.profile;
-        } else if (Object.keys(this.profiles).length > 1) {
+            creds.profile = argv.profile;
+        } else if (creds.dotdeploy.profile) {
+            creds.profile = creds.dotdeploy.profile;
+        } else if (Object.keys(creds.profiles).length > 1) {
             throw new Error('Multiple deploy profiles found. Deploy with --profile or set a .deploy file');
         } else {
-            this.profile = Object.keys(this.profiles)[0];
+            creds.profile = Object.keys(creds.profiles)[0];
         }
 
-        if (!this.profiles[this.profile]) this.profiles[this.profile] = {};
+        if (!creds.profiles[creds.profile]) creds.profiles[creds.profile] = {};
 
         PROFILE_KEYS.forEach((key) => {
-            if (this.profiles[this.profile][key] !== undefined) {
-                this[key] = this.profiles[this.profile][key];
+            if (creds.profiles[creds.profile][key] !== undefined) {
+                creds[key] = creds.profiles[creds.profile][key];
             }
         });
 
         if (argv.name) {
-            this.name = argv.name.replace(new RegExp(`^${this.repo}-`, ''));
+            creds.name = argv.name.replace(new RegExp(`^${creds.repo}-`, ''));
         } else {
-            this.name = (this.subname || '') + this.stack;
+            creds.name = (creds.subname || '') + creds.stack;
         }
 
-        if (!readcreds[this.profile]) {
-            readcreds[this.profile] = {};
+        if (!readcreds[creds.profile]) {
+            readcreds[creds.profile] = {};
         }
 
-        if (readcreds[this.profile].tags) {
-            this.tags = this.tags.concat(readcreds[this.profile].tags);
+        if (readcreds[creds.profile].tags) {
+            creds.tags = creds.tags.concat(readcreds[creds.profile].tags);
         }
 
-        if (this.dotdeploy.tags) {
-            this.tags = this.tags.concat(this.dotdeploy.tags || []);
+        if (creds.dotdeploy.tags) {
+            creds.tags = creds.tags.concat(creds.dotdeploy.tags || []);
         }
+
+        creds.aws = {};
 
         try {
-            if (!this.accessKeyId || !this.secretAccessKey) {
-                // If there is no accesskey/secret access key, see if we can obtain them from the aws credentials
-                const awscreds = new AWS.SharedIniFileCredentials({
-                    profile: this.profile
-                });
-
-                this.accessKeyId = awscreds.accessKeyId;
-                this.secretAccessKey = awscreds.secretAccessKey;
-                this.sessionToken = awscreds.sessionToken;
-            }
-
-            AWS.config.credentials = new AWS.Credentials({
-                region: this.region,
-                accessKeyId: this.accessKeyId,
-                secretAccessKey: this.secretAccessKey,
-                sessionToken: this.sessionToken,
-            });
+             creds.aws= await (await fromIni({
+                profile: creds.profile
+            })());
         } catch (err) {
             throw new Error('creds not set: run deploy init');
         }
+
+        return creds;
     }
 
     /**
@@ -232,9 +218,17 @@ export default class Credentials {
     async accountId() {
         if (this._accountId) return this._accountId;
 
-        const STS = new AWS.STS({ region: this.region });
+        const sts = new STSClient({
+            credentials: {
+                accessKeyId: this.accessKeyId,
+                secretAccessKey: this.secretAccessKey,
+                sessionToken: this.sessionToken
+            },
+            region: this.region
+        });
 
-        const account = await STS.getCallerIdentity().promise();
+        const account = await STS.send(new GetCallerIdentityComment());
+        console.error(account);
         this._accountId = account.Account;
 
         return this._accountId;

--- a/lib/creds.js
+++ b/lib/creds.js
@@ -219,11 +219,7 @@ export default class Credentials {
         if (this._accountId) return this._accountId;
 
         const sts = new STSClient({
-            credentials: {
-                accessKeyId: this.accessKeyId,
-                secretAccessKey: this.secretAccessKey,
-                sessionToken: this.sessionToken
-            },
+            credentials: this.aws,
             region: this.region
         });
 

--- a/lib/creds.js
+++ b/lib/creds.js
@@ -227,8 +227,7 @@ export default class Credentials {
             region: this.region
         });
 
-        const account = await STS.send(new GetCallerIdentityComment());
-        console.error(account);
+        const account = await sts.send(new GetCallerIdentityCommand());
         this._accountId = account.Account;
 
         return this._accountId;

--- a/lib/creds.js
+++ b/lib/creds.js
@@ -11,7 +11,7 @@ const ajv = new AJV({
 
 // Only these keys are allowed to overwrite Credentials keys
 // when loaded from a .deployrc.json file
-const PROFILE_KEYS = [ 'region', 'github' ];
+const PROFILE_KEYS = ['region', 'github'];
 
 /**
  * Store all credentials required for deploy functionality
@@ -169,7 +169,7 @@ export default class Credentials {
         creds.aws = {};
 
         try {
-             creds.aws= await (await fromIni({
+            creds.aws = await (await fromIni({
                 profile: creds.profile
             })());
         } catch (err) {

--- a/lib/info.js
+++ b/lib/info.js
@@ -1,7 +1,7 @@
 import Table from 'cli-table';
 import minimist from 'minimist';
 import CFN from '@openaddresses/cfn-config';
-import AWS from 'aws-sdk';
+import { SecretsManagerClient, GetSecretValueCommand } from '@aws-sdk/client-secrets-manager';
 
 /**
  * @class
@@ -43,11 +43,12 @@ export default class Info {
 
         if (!creds.stack) return console.error('Stack name required: run deploy info --help');
 
-        const sm = new AWS.SecretsManager({
+        const sm = new SecretsManagerClient({
+            credentials: creds.aws,
             region: creds.region
         });
 
-        const cfn = CFN.preauth(creds);
+        const cfn = CFN.preauth({ ...creds, ...creds.aws });
         const info = await cfn.Lookup.info(`${creds.repo}-${creds.stack}`, creds.region, true, false);
 
         for (const key of Object.keys(info.Outputs)) {
@@ -60,10 +61,10 @@ export default class Info {
                 if (!parsed[2]) parsed[2] = '';
                 if (!parsed[3]) parsed[3] = 'AWSCURRENT';
 
-                let val = await sm.getSecretValue({
+                let val = await sm.send(new GetSecretValueCommand({
                     SecretId: parsed[0],
                     VersionStage: parsed[3]
-                }).promise();
+                }));
 
                 if (!parsed[2]) {
                     val = val.SecretString;

--- a/lib/init.js
+++ b/lib/init.js
@@ -1,7 +1,8 @@
 import fs from 'fs/promises';
 import path from 'path';
 import prompt from 'prompt';
-import AWS from 'aws-sdk';
+import { fromIni } from '@aws-sdk/credential-providers';
+import { S3Client, HeadBucketCommand, CreateBucketCommand } from '@aws-sdk/client-s3';
 
 prompt.message = '$';
 
@@ -40,23 +41,15 @@ export default class Init {
             default: 'us-east-1'
         }]);
 
-        const awscreds = new AWS.SharedIniFileCredentials({
+
+        const awscreds = await (await fromIni({
             profile: argv['profile-name']
-        });
+        })());
+
 
         // If credentials don't exist in aws credentials, request them
         if (!awscreds.accessKeyId) {
-            Object.assign(argv, await prompt.get([{
-                name: 'accessKeyId',
-                type: 'string',
-                required: true
-            },{
-                name: 'secretAccessKey',
-                hidden: true,
-                replace: '*',
-                required: true,
-                type: 'string'
-            }]));
+            throw new Error(`No profile for ${argv['profile-name']} found in ~/.aws/credentials`);
         }
 
         let creds;
@@ -82,17 +75,20 @@ export default class Init {
      * @param {Credentials} creds
      */
     static async bucket(creds) {
-        const s3 = new AWS.S3({ region: creds.region });
+        const s3 = new S3Client({
+            credentials: creds.aws,
+            region: creds.region
+        });
 
         for (const Bucket of ['cfn-config-templates-', 'cfn-config-active-']) {
             if (!creds.region) continue;
 
             const full = Bucket + await creds.accountId() + '-' + creds.region;
             try {
-                await s3.headBucket({
+                await s3.send(new HeadBucketCommand({
                     Bucket: full,
                     ExpectedBucketOwner: await creds.accountId()
-                }).promise();
+                }));
             } catch (err) {
                 if (err.code === 'NotFound') {
                     prompt.start();
@@ -107,9 +103,9 @@ export default class Init {
 
                     if (argv.create.toLowerCase() !== 'y') continue;
 
-                    await s3.createBucket({
+                    await s3.send(new CreateBucketCommand({
                         Bucket: full
-                    }).promise();
+                    }));
                 }
             }
         }

--- a/lib/list.js
+++ b/lib/list.js
@@ -1,4 +1,4 @@
-import AWS from 'aws-sdk';
+import { CloudFormationClient, ListStacksCommand } from '@aws-sdk/client-cloudformation';
 import minimist from 'minimist';
 
 /**
@@ -51,9 +51,11 @@ export default class List {
         }
 
         for (const region of regions) {
-            const cloudformation = new AWS.CloudFormation({ region });
+            const cf = new CloudFormationClient({
+                region, credentials: creds.aws
+            });
 
-            const res = await cloudformation.listStacks({
+            const res = await cf.send(new ListStacksCommand({
                 // All but "DELETE_COMPLETE"
                 StackStatusFilter: [
                     'CREATE_IN_PROGRESS',
@@ -72,7 +74,7 @@ export default class List {
                     'UPDATE_ROLLBACK_COMPLETE_CLEANUP_IN_PROGRESS',
                     'UPDATE_ROLLBACK_COMPLETE'
                 ]
-            }).promise();
+            }));
 
             console.log(`# Region: ${region}`);
             for (const stack of res.StackSummaries) {

--- a/lib/list.js
+++ b/lib/list.js
@@ -1,4 +1,5 @@
 import { CloudFormationClient, ListStacksCommand } from '@aws-sdk/client-cloudformation';
+import { EC2Client, DescribeRegionsCommand } from '@aws-sdk/client-ec2';
 import minimist from 'minimist';
 
 /**
@@ -39,11 +40,12 @@ export default class List {
         const regions = [];
 
         if (argv.all) {
-            const ec2 = new AWS.EC2({
+            const ec2 = new EC2Client({
+                credentials: creds.aws,
                 region: creds.region
             });
 
-            (await ec2.describeRegions().promise()).Regions.forEach((region) => {
+            (await ec2.send(new DescribeRegionsCommand())).Regions.forEach((region) => {
                 regions.push(region.Endpoint.replace('ec2.', '').replace('.amazonaws.com', ''));
             });
         } else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
             "license": "MIT",
             "dependencies": {
                 "@aws-sdk/client-cloudformation": "^3.272.0",
+                "@aws-sdk/client-ec2": "^3.272.0",
                 "@aws-sdk/client-ecr": "^3.272.0",
                 "@aws-sdk/client-s3": "^3.272.0",
                 "@aws-sdk/client-secrets-manager": "^3.272.0",
@@ -299,6 +300,63 @@
             },
             "engines": {
                 "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-ec2": {
+            "version": "3.272.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-ec2/-/client-ec2-3.272.0.tgz",
+            "integrity": "sha512-pL20nbakJHuS26pyB9tYDQlw8/R2BP1sSmr+GIE2G+IZdCuB9kI9AHklwqZLEZfgJXsxkiIWoL3icPrIJH5piA==",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "3.0.0",
+                "@aws-crypto/sha256-js": "3.0.0",
+                "@aws-sdk/client-sts": "3.272.0",
+                "@aws-sdk/config-resolver": "3.272.0",
+                "@aws-sdk/credential-provider-node": "3.272.0",
+                "@aws-sdk/fetch-http-handler": "3.272.0",
+                "@aws-sdk/hash-node": "3.272.0",
+                "@aws-sdk/invalid-dependency": "3.272.0",
+                "@aws-sdk/middleware-content-length": "3.272.0",
+                "@aws-sdk/middleware-endpoint": "3.272.0",
+                "@aws-sdk/middleware-host-header": "3.272.0",
+                "@aws-sdk/middleware-logger": "3.272.0",
+                "@aws-sdk/middleware-recursion-detection": "3.272.0",
+                "@aws-sdk/middleware-retry": "3.272.0",
+                "@aws-sdk/middleware-sdk-ec2": "3.272.0",
+                "@aws-sdk/middleware-serde": "3.272.0",
+                "@aws-sdk/middleware-signing": "3.272.0",
+                "@aws-sdk/middleware-stack": "3.272.0",
+                "@aws-sdk/middleware-user-agent": "3.272.0",
+                "@aws-sdk/node-config-provider": "3.272.0",
+                "@aws-sdk/node-http-handler": "3.272.0",
+                "@aws-sdk/protocol-http": "3.272.0",
+                "@aws-sdk/smithy-client": "3.272.0",
+                "@aws-sdk/types": "3.272.0",
+                "@aws-sdk/url-parser": "3.272.0",
+                "@aws-sdk/util-base64": "3.208.0",
+                "@aws-sdk/util-body-length-browser": "3.188.0",
+                "@aws-sdk/util-body-length-node": "3.208.0",
+                "@aws-sdk/util-defaults-mode-browser": "3.272.0",
+                "@aws-sdk/util-defaults-mode-node": "3.272.0",
+                "@aws-sdk/util-endpoints": "3.272.0",
+                "@aws-sdk/util-retry": "3.272.0",
+                "@aws-sdk/util-user-agent-browser": "3.272.0",
+                "@aws-sdk/util-user-agent-node": "3.272.0",
+                "@aws-sdk/util-utf8": "3.254.0",
+                "@aws-sdk/util-waiter": "3.272.0",
+                "fast-xml-parser": "4.0.11",
+                "tslib": "^2.3.1",
+                "uuid": "^8.3.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-ec2/node_modules/uuid": {
+            "version": "8.3.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+            "bin": {
+                "uuid": "dist/bin/uuid"
             }
         },
         "node_modules/@aws-sdk/client-ecr": {
@@ -1052,6 +1110,22 @@
                 "uuid": "dist/bin/uuid"
             }
         },
+        "node_modules/@aws-sdk/middleware-sdk-ec2": {
+            "version": "3.272.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-ec2/-/middleware-sdk-ec2-3.272.0.tgz",
+            "integrity": "sha512-kjIp7mmSRQSGzjVP6thhPGIOLHvc8pg7rQggv8YpzpmhDVZ4gkkLqDDuYlPNJDXqiYuDEcqnwFff+w2wQze+Dw==",
+            "dependencies": {
+                "@aws-sdk/middleware-endpoint": "3.272.0",
+                "@aws-sdk/protocol-http": "3.272.0",
+                "@aws-sdk/signature-v4": "3.272.0",
+                "@aws-sdk/types": "3.272.0",
+                "@aws-sdk/util-format-url": "3.272.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
         "node_modules/@aws-sdk/middleware-sdk-s3": {
             "version": "3.272.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.272.0.tgz",
@@ -1433,6 +1507,19 @@
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.272.0.tgz",
             "integrity": "sha512-c4MPUaJt2G6gGpoiwIOqDfUa98c1J63RpYvf/spQEKOtC/tF5Gfqlxuq8FnAl5lHnrqj1B9ZXLLxFhHtDR0IiQ==",
             "dependencies": {
+                "@aws-sdk/types": "3.272.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-format-url": {
+            "version": "3.272.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.272.0.tgz",
+            "integrity": "sha512-ZvYRnzDOjyR7UEZtCicDcV80nuk148IaBJfnzacVdsB3eu+rCcqZDCuGao/jKGNZGroMHmL8b4Tskwc4vZlDDw==",
+            "dependencies": {
+                "@aws-sdk/querystring-builder": "3.272.0",
                 "@aws-sdk/types": "3.272.0",
                 "tslib": "^2.3.1"
             },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,22 @@
 {
     "name": "@openaddresses/deploy",
-    "version": "7.5.0",
+    "version": "7.6.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@openaddresses/deploy",
-            "version": "7.5.0",
+            "version": "7.6.0",
             "license": "MIT",
             "dependencies": {
+                "@aws-sdk/client-cloudformation": "^3.272.0",
+                "@aws-sdk/client-ecr": "^3.272.0",
+                "@aws-sdk/client-s3": "^3.272.0",
+                "@aws-sdk/client-secrets-manager": "^3.272.0",
+                "@aws-sdk/credential-providers": "^3.272.0",
                 "@octokit/rest": "^19.0.0",
-                "@openaddresses/cfn-config": "^6.3.0",
+                "@openaddresses/cfn-config": "^6.4.0",
                 "ajv": "^8.6.3",
-                "aws-sdk": "^2.656.0",
                 "cli-table": "^0.3.1",
                 "handlebars": "^4.7.7",
                 "inquirer": "^9.0.0",
@@ -40,6 +44,1558 @@
             },
             "engines": {
                 "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@aws-crypto/crc32": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-3.0.0.tgz",
+            "integrity": "sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==",
+            "dependencies": {
+                "@aws-crypto/util": "^3.0.0",
+                "@aws-sdk/types": "^3.222.0",
+                "tslib": "^1.11.1"
+            }
+        },
+        "node_modules/@aws-crypto/crc32/node_modules/tslib": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        },
+        "node_modules/@aws-crypto/crc32c": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-3.0.0.tgz",
+            "integrity": "sha512-ENNPPManmnVJ4BTXlOjAgD7URidbAznURqD0KvfREyc4o20DPYdEldU1f5cQ7Jbj0CJJSPaMIk/9ZshdB3210w==",
+            "dependencies": {
+                "@aws-crypto/util": "^3.0.0",
+                "@aws-sdk/types": "^3.222.0",
+                "tslib": "^1.11.1"
+            }
+        },
+        "node_modules/@aws-crypto/crc32c/node_modules/tslib": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        },
+        "node_modules/@aws-crypto/ie11-detection": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
+            "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
+            "dependencies": {
+                "tslib": "^1.11.1"
+            }
+        },
+        "node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        },
+        "node_modules/@aws-crypto/sha1-browser": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/sha1-browser/-/sha1-browser-3.0.0.tgz",
+            "integrity": "sha512-NJth5c997GLHs6nOYTzFKTbYdMNA6/1XlKVgnZoaZcQ7z7UJlOgj2JdbHE8tiYLS3fzXNCguct77SPGat2raSw==",
+            "dependencies": {
+                "@aws-crypto/ie11-detection": "^3.0.0",
+                "@aws-crypto/supports-web-crypto": "^3.0.0",
+                "@aws-crypto/util": "^3.0.0",
+                "@aws-sdk/types": "^3.222.0",
+                "@aws-sdk/util-locate-window": "^3.0.0",
+                "@aws-sdk/util-utf8-browser": "^3.0.0",
+                "tslib": "^1.11.1"
+            }
+        },
+        "node_modules/@aws-crypto/sha1-browser/node_modules/tslib": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        },
+        "node_modules/@aws-crypto/sha256-browser": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
+            "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
+            "dependencies": {
+                "@aws-crypto/ie11-detection": "^3.0.0",
+                "@aws-crypto/sha256-js": "^3.0.0",
+                "@aws-crypto/supports-web-crypto": "^3.0.0",
+                "@aws-crypto/util": "^3.0.0",
+                "@aws-sdk/types": "^3.222.0",
+                "@aws-sdk/util-locate-window": "^3.0.0",
+                "@aws-sdk/util-utf8-browser": "^3.0.0",
+                "tslib": "^1.11.1"
+            }
+        },
+        "node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        },
+        "node_modules/@aws-crypto/sha256-js": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
+            "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
+            "dependencies": {
+                "@aws-crypto/util": "^3.0.0",
+                "@aws-sdk/types": "^3.222.0",
+                "tslib": "^1.11.1"
+            }
+        },
+        "node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        },
+        "node_modules/@aws-crypto/supports-web-crypto": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
+            "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
+            "dependencies": {
+                "tslib": "^1.11.1"
+            }
+        },
+        "node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        },
+        "node_modules/@aws-crypto/util": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
+            "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
+            "dependencies": {
+                "@aws-sdk/types": "^3.222.0",
+                "@aws-sdk/util-utf8-browser": "^3.0.0",
+                "tslib": "^1.11.1"
+            }
+        },
+        "node_modules/@aws-crypto/util/node_modules/tslib": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        },
+        "node_modules/@aws-sdk/abort-controller": {
+            "version": "3.272.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.272.0.tgz",
+            "integrity": "sha512-s2TV3phapcTwZNr4qLxbfuQuE9ZMP4RoJdkvRRCkKdm6jslsWLJf2Zlcxti/23hOlINUMYv2iXE2pftIgWGdpg==",
+            "dependencies": {
+                "@aws-sdk/types": "3.272.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/chunked-blob-reader": {
+            "version": "3.188.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader/-/chunked-blob-reader-3.188.0.tgz",
+            "integrity": "sha512-zkPRFZZPL3eH+kH86LDYYXImiClA1/sW60zYOjse9Pgka+eDJlvBN6hcYxwDEKjcwATYiSRR1aVQHcfCinlGXg==",
+            "dependencies": {
+                "tslib": "^2.3.1"
+            }
+        },
+        "node_modules/@aws-sdk/chunked-blob-reader-native": {
+            "version": "3.208.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader-native/-/chunked-blob-reader-native-3.208.0.tgz",
+            "integrity": "sha512-JeOZ95PW+fJ6bbuqPySYqLqHk1n4+4ueEEraJsiUrPBV0S1ZtyvOGHcnGztKUjr2PYNaiexmpWuvUve9K12HRA==",
+            "dependencies": {
+                "@aws-sdk/util-base64": "3.208.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "node_modules/@aws-sdk/client-cloudformation": {
+            "version": "3.272.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudformation/-/client-cloudformation-3.272.0.tgz",
+            "integrity": "sha512-7SbeuRT68EhTS1E4WmrXYmIUfEocd0LVGpTPbSuLVkNgBqcpZnZJ5gvcIP2LRTY9S7dlkUThgwrgsRZ5+DHUmg==",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "3.0.0",
+                "@aws-crypto/sha256-js": "3.0.0",
+                "@aws-sdk/client-sts": "3.272.0",
+                "@aws-sdk/config-resolver": "3.272.0",
+                "@aws-sdk/credential-provider-node": "3.272.0",
+                "@aws-sdk/fetch-http-handler": "3.272.0",
+                "@aws-sdk/hash-node": "3.272.0",
+                "@aws-sdk/invalid-dependency": "3.272.0",
+                "@aws-sdk/middleware-content-length": "3.272.0",
+                "@aws-sdk/middleware-endpoint": "3.272.0",
+                "@aws-sdk/middleware-host-header": "3.272.0",
+                "@aws-sdk/middleware-logger": "3.272.0",
+                "@aws-sdk/middleware-recursion-detection": "3.272.0",
+                "@aws-sdk/middleware-retry": "3.272.0",
+                "@aws-sdk/middleware-serde": "3.272.0",
+                "@aws-sdk/middleware-signing": "3.272.0",
+                "@aws-sdk/middleware-stack": "3.272.0",
+                "@aws-sdk/middleware-user-agent": "3.272.0",
+                "@aws-sdk/node-config-provider": "3.272.0",
+                "@aws-sdk/node-http-handler": "3.272.0",
+                "@aws-sdk/protocol-http": "3.272.0",
+                "@aws-sdk/smithy-client": "3.272.0",
+                "@aws-sdk/types": "3.272.0",
+                "@aws-sdk/url-parser": "3.272.0",
+                "@aws-sdk/util-base64": "3.208.0",
+                "@aws-sdk/util-body-length-browser": "3.188.0",
+                "@aws-sdk/util-body-length-node": "3.208.0",
+                "@aws-sdk/util-defaults-mode-browser": "3.272.0",
+                "@aws-sdk/util-defaults-mode-node": "3.272.0",
+                "@aws-sdk/util-endpoints": "3.272.0",
+                "@aws-sdk/util-retry": "3.272.0",
+                "@aws-sdk/util-user-agent-browser": "3.272.0",
+                "@aws-sdk/util-user-agent-node": "3.272.0",
+                "@aws-sdk/util-utf8": "3.254.0",
+                "@aws-sdk/util-waiter": "3.272.0",
+                "fast-xml-parser": "4.0.11",
+                "tslib": "^2.3.1",
+                "uuid": "^8.3.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cloudformation/node_modules/uuid": {
+            "version": "8.3.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+            "bin": {
+                "uuid": "dist/bin/uuid"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity": {
+            "version": "3.272.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.272.0.tgz",
+            "integrity": "sha512-uMjRWcNvX7SoGaVn0mXWD43+Z1awPahQwGW3riDLfXHZdOgw2oFDhD3Jg5jQ8OzQLUfDvArhE3WyZwlS4muMuQ==",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "3.0.0",
+                "@aws-crypto/sha256-js": "3.0.0",
+                "@aws-sdk/client-sts": "3.272.0",
+                "@aws-sdk/config-resolver": "3.272.0",
+                "@aws-sdk/credential-provider-node": "3.272.0",
+                "@aws-sdk/fetch-http-handler": "3.272.0",
+                "@aws-sdk/hash-node": "3.272.0",
+                "@aws-sdk/invalid-dependency": "3.272.0",
+                "@aws-sdk/middleware-content-length": "3.272.0",
+                "@aws-sdk/middleware-endpoint": "3.272.0",
+                "@aws-sdk/middleware-host-header": "3.272.0",
+                "@aws-sdk/middleware-logger": "3.272.0",
+                "@aws-sdk/middleware-recursion-detection": "3.272.0",
+                "@aws-sdk/middleware-retry": "3.272.0",
+                "@aws-sdk/middleware-serde": "3.272.0",
+                "@aws-sdk/middleware-signing": "3.272.0",
+                "@aws-sdk/middleware-stack": "3.272.0",
+                "@aws-sdk/middleware-user-agent": "3.272.0",
+                "@aws-sdk/node-config-provider": "3.272.0",
+                "@aws-sdk/node-http-handler": "3.272.0",
+                "@aws-sdk/protocol-http": "3.272.0",
+                "@aws-sdk/smithy-client": "3.272.0",
+                "@aws-sdk/types": "3.272.0",
+                "@aws-sdk/url-parser": "3.272.0",
+                "@aws-sdk/util-base64": "3.208.0",
+                "@aws-sdk/util-body-length-browser": "3.188.0",
+                "@aws-sdk/util-body-length-node": "3.208.0",
+                "@aws-sdk/util-defaults-mode-browser": "3.272.0",
+                "@aws-sdk/util-defaults-mode-node": "3.272.0",
+                "@aws-sdk/util-endpoints": "3.272.0",
+                "@aws-sdk/util-retry": "3.272.0",
+                "@aws-sdk/util-user-agent-browser": "3.272.0",
+                "@aws-sdk/util-user-agent-node": "3.272.0",
+                "@aws-sdk/util-utf8": "3.254.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-ecr": {
+            "version": "3.272.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-ecr/-/client-ecr-3.272.0.tgz",
+            "integrity": "sha512-3AehcYlzxVxxQ4Hf841dIM77Lyz/6iS7GrZzZj744w16aWmmJwtI7n9QcCmf3C/yMYURRdt5fn9y0Sw42MjLdA==",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "3.0.0",
+                "@aws-crypto/sha256-js": "3.0.0",
+                "@aws-sdk/client-sts": "3.272.0",
+                "@aws-sdk/config-resolver": "3.272.0",
+                "@aws-sdk/credential-provider-node": "3.272.0",
+                "@aws-sdk/fetch-http-handler": "3.272.0",
+                "@aws-sdk/hash-node": "3.272.0",
+                "@aws-sdk/invalid-dependency": "3.272.0",
+                "@aws-sdk/middleware-content-length": "3.272.0",
+                "@aws-sdk/middleware-endpoint": "3.272.0",
+                "@aws-sdk/middleware-host-header": "3.272.0",
+                "@aws-sdk/middleware-logger": "3.272.0",
+                "@aws-sdk/middleware-recursion-detection": "3.272.0",
+                "@aws-sdk/middleware-retry": "3.272.0",
+                "@aws-sdk/middleware-serde": "3.272.0",
+                "@aws-sdk/middleware-signing": "3.272.0",
+                "@aws-sdk/middleware-stack": "3.272.0",
+                "@aws-sdk/middleware-user-agent": "3.272.0",
+                "@aws-sdk/node-config-provider": "3.272.0",
+                "@aws-sdk/node-http-handler": "3.272.0",
+                "@aws-sdk/protocol-http": "3.272.0",
+                "@aws-sdk/smithy-client": "3.272.0",
+                "@aws-sdk/types": "3.272.0",
+                "@aws-sdk/url-parser": "3.272.0",
+                "@aws-sdk/util-base64": "3.208.0",
+                "@aws-sdk/util-body-length-browser": "3.188.0",
+                "@aws-sdk/util-body-length-node": "3.208.0",
+                "@aws-sdk/util-defaults-mode-browser": "3.272.0",
+                "@aws-sdk/util-defaults-mode-node": "3.272.0",
+                "@aws-sdk/util-endpoints": "3.272.0",
+                "@aws-sdk/util-retry": "3.272.0",
+                "@aws-sdk/util-user-agent-browser": "3.272.0",
+                "@aws-sdk/util-user-agent-node": "3.272.0",
+                "@aws-sdk/util-utf8": "3.254.0",
+                "@aws-sdk/util-waiter": "3.272.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-s3": {
+            "version": "3.272.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.272.0.tgz",
+            "integrity": "sha512-KxlVhTHfmcm3HlAP5+vY1cuQt60AaYOISp1ccYOPsww7Ly7fbDnbov0AV9bcwlLLVcfZFWQYJqH+Gvk2SpyXFQ==",
+            "dependencies": {
+                "@aws-crypto/sha1-browser": "3.0.0",
+                "@aws-crypto/sha256-browser": "3.0.0",
+                "@aws-crypto/sha256-js": "3.0.0",
+                "@aws-sdk/client-sts": "3.272.0",
+                "@aws-sdk/config-resolver": "3.272.0",
+                "@aws-sdk/credential-provider-node": "3.272.0",
+                "@aws-sdk/eventstream-serde-browser": "3.272.0",
+                "@aws-sdk/eventstream-serde-config-resolver": "3.272.0",
+                "@aws-sdk/eventstream-serde-node": "3.272.0",
+                "@aws-sdk/fetch-http-handler": "3.272.0",
+                "@aws-sdk/hash-blob-browser": "3.272.0",
+                "@aws-sdk/hash-node": "3.272.0",
+                "@aws-sdk/hash-stream-node": "3.272.0",
+                "@aws-sdk/invalid-dependency": "3.272.0",
+                "@aws-sdk/md5-js": "3.272.0",
+                "@aws-sdk/middleware-bucket-endpoint": "3.272.0",
+                "@aws-sdk/middleware-content-length": "3.272.0",
+                "@aws-sdk/middleware-endpoint": "3.272.0",
+                "@aws-sdk/middleware-expect-continue": "3.272.0",
+                "@aws-sdk/middleware-flexible-checksums": "3.272.0",
+                "@aws-sdk/middleware-host-header": "3.272.0",
+                "@aws-sdk/middleware-location-constraint": "3.272.0",
+                "@aws-sdk/middleware-logger": "3.272.0",
+                "@aws-sdk/middleware-recursion-detection": "3.272.0",
+                "@aws-sdk/middleware-retry": "3.272.0",
+                "@aws-sdk/middleware-sdk-s3": "3.272.0",
+                "@aws-sdk/middleware-serde": "3.272.0",
+                "@aws-sdk/middleware-signing": "3.272.0",
+                "@aws-sdk/middleware-ssec": "3.272.0",
+                "@aws-sdk/middleware-stack": "3.272.0",
+                "@aws-sdk/middleware-user-agent": "3.272.0",
+                "@aws-sdk/node-config-provider": "3.272.0",
+                "@aws-sdk/node-http-handler": "3.272.0",
+                "@aws-sdk/protocol-http": "3.272.0",
+                "@aws-sdk/signature-v4-multi-region": "3.272.0",
+                "@aws-sdk/smithy-client": "3.272.0",
+                "@aws-sdk/types": "3.272.0",
+                "@aws-sdk/url-parser": "3.272.0",
+                "@aws-sdk/util-base64": "3.208.0",
+                "@aws-sdk/util-body-length-browser": "3.188.0",
+                "@aws-sdk/util-body-length-node": "3.208.0",
+                "@aws-sdk/util-defaults-mode-browser": "3.272.0",
+                "@aws-sdk/util-defaults-mode-node": "3.272.0",
+                "@aws-sdk/util-endpoints": "3.272.0",
+                "@aws-sdk/util-retry": "3.272.0",
+                "@aws-sdk/util-stream-browser": "3.272.0",
+                "@aws-sdk/util-stream-node": "3.272.0",
+                "@aws-sdk/util-user-agent-browser": "3.272.0",
+                "@aws-sdk/util-user-agent-node": "3.272.0",
+                "@aws-sdk/util-utf8": "3.254.0",
+                "@aws-sdk/util-waiter": "3.272.0",
+                "@aws-sdk/xml-builder": "3.201.0",
+                "fast-xml-parser": "4.0.11",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-secrets-manager": {
+            "version": "3.272.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.272.0.tgz",
+            "integrity": "sha512-dKTl+vFyo7Sqy63AxRO3D2aSnwUK9yQajfWzN9Fhu7z2/iit11t5oaTPndSmAwHpFY9+YySdwqtYUGu3413rUA==",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "3.0.0",
+                "@aws-crypto/sha256-js": "3.0.0",
+                "@aws-sdk/client-sts": "3.272.0",
+                "@aws-sdk/config-resolver": "3.272.0",
+                "@aws-sdk/credential-provider-node": "3.272.0",
+                "@aws-sdk/fetch-http-handler": "3.272.0",
+                "@aws-sdk/hash-node": "3.272.0",
+                "@aws-sdk/invalid-dependency": "3.272.0",
+                "@aws-sdk/middleware-content-length": "3.272.0",
+                "@aws-sdk/middleware-endpoint": "3.272.0",
+                "@aws-sdk/middleware-host-header": "3.272.0",
+                "@aws-sdk/middleware-logger": "3.272.0",
+                "@aws-sdk/middleware-recursion-detection": "3.272.0",
+                "@aws-sdk/middleware-retry": "3.272.0",
+                "@aws-sdk/middleware-serde": "3.272.0",
+                "@aws-sdk/middleware-signing": "3.272.0",
+                "@aws-sdk/middleware-stack": "3.272.0",
+                "@aws-sdk/middleware-user-agent": "3.272.0",
+                "@aws-sdk/node-config-provider": "3.272.0",
+                "@aws-sdk/node-http-handler": "3.272.0",
+                "@aws-sdk/protocol-http": "3.272.0",
+                "@aws-sdk/smithy-client": "3.272.0",
+                "@aws-sdk/types": "3.272.0",
+                "@aws-sdk/url-parser": "3.272.0",
+                "@aws-sdk/util-base64": "3.208.0",
+                "@aws-sdk/util-body-length-browser": "3.188.0",
+                "@aws-sdk/util-body-length-node": "3.208.0",
+                "@aws-sdk/util-defaults-mode-browser": "3.272.0",
+                "@aws-sdk/util-defaults-mode-node": "3.272.0",
+                "@aws-sdk/util-endpoints": "3.272.0",
+                "@aws-sdk/util-retry": "3.272.0",
+                "@aws-sdk/util-user-agent-browser": "3.272.0",
+                "@aws-sdk/util-user-agent-node": "3.272.0",
+                "@aws-sdk/util-utf8": "3.254.0",
+                "tslib": "^2.3.1",
+                "uuid": "^8.3.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-secrets-manager/node_modules/uuid": {
+            "version": "8.3.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+            "bin": {
+                "uuid": "dist/bin/uuid"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso": {
+            "version": "3.272.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.272.0.tgz",
+            "integrity": "sha512-xn9a0IGONwQIARmngThoRhF1lLGjHAD67sUaShgIMaIMc6ipVYN6alWG1VuUpoUQ6iiwMEt0CHdfCyLyUV/fTA==",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "3.0.0",
+                "@aws-crypto/sha256-js": "3.0.0",
+                "@aws-sdk/config-resolver": "3.272.0",
+                "@aws-sdk/fetch-http-handler": "3.272.0",
+                "@aws-sdk/hash-node": "3.272.0",
+                "@aws-sdk/invalid-dependency": "3.272.0",
+                "@aws-sdk/middleware-content-length": "3.272.0",
+                "@aws-sdk/middleware-endpoint": "3.272.0",
+                "@aws-sdk/middleware-host-header": "3.272.0",
+                "@aws-sdk/middleware-logger": "3.272.0",
+                "@aws-sdk/middleware-recursion-detection": "3.272.0",
+                "@aws-sdk/middleware-retry": "3.272.0",
+                "@aws-sdk/middleware-serde": "3.272.0",
+                "@aws-sdk/middleware-stack": "3.272.0",
+                "@aws-sdk/middleware-user-agent": "3.272.0",
+                "@aws-sdk/node-config-provider": "3.272.0",
+                "@aws-sdk/node-http-handler": "3.272.0",
+                "@aws-sdk/protocol-http": "3.272.0",
+                "@aws-sdk/smithy-client": "3.272.0",
+                "@aws-sdk/types": "3.272.0",
+                "@aws-sdk/url-parser": "3.272.0",
+                "@aws-sdk/util-base64": "3.208.0",
+                "@aws-sdk/util-body-length-browser": "3.188.0",
+                "@aws-sdk/util-body-length-node": "3.208.0",
+                "@aws-sdk/util-defaults-mode-browser": "3.272.0",
+                "@aws-sdk/util-defaults-mode-node": "3.272.0",
+                "@aws-sdk/util-endpoints": "3.272.0",
+                "@aws-sdk/util-retry": "3.272.0",
+                "@aws-sdk/util-user-agent-browser": "3.272.0",
+                "@aws-sdk/util-user-agent-node": "3.272.0",
+                "@aws-sdk/util-utf8": "3.254.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso-oidc": {
+            "version": "3.272.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.272.0.tgz",
+            "integrity": "sha512-ECcXu3xoa1yggnGKMTh29eWNHiF/wC6r5Uqbla22eOOosyh0+Z6lkJ3JUSLOUKCkBXA4Cs/tJL9UDFBrKbSlvA==",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "3.0.0",
+                "@aws-crypto/sha256-js": "3.0.0",
+                "@aws-sdk/config-resolver": "3.272.0",
+                "@aws-sdk/fetch-http-handler": "3.272.0",
+                "@aws-sdk/hash-node": "3.272.0",
+                "@aws-sdk/invalid-dependency": "3.272.0",
+                "@aws-sdk/middleware-content-length": "3.272.0",
+                "@aws-sdk/middleware-endpoint": "3.272.0",
+                "@aws-sdk/middleware-host-header": "3.272.0",
+                "@aws-sdk/middleware-logger": "3.272.0",
+                "@aws-sdk/middleware-recursion-detection": "3.272.0",
+                "@aws-sdk/middleware-retry": "3.272.0",
+                "@aws-sdk/middleware-serde": "3.272.0",
+                "@aws-sdk/middleware-stack": "3.272.0",
+                "@aws-sdk/middleware-user-agent": "3.272.0",
+                "@aws-sdk/node-config-provider": "3.272.0",
+                "@aws-sdk/node-http-handler": "3.272.0",
+                "@aws-sdk/protocol-http": "3.272.0",
+                "@aws-sdk/smithy-client": "3.272.0",
+                "@aws-sdk/types": "3.272.0",
+                "@aws-sdk/url-parser": "3.272.0",
+                "@aws-sdk/util-base64": "3.208.0",
+                "@aws-sdk/util-body-length-browser": "3.188.0",
+                "@aws-sdk/util-body-length-node": "3.208.0",
+                "@aws-sdk/util-defaults-mode-browser": "3.272.0",
+                "@aws-sdk/util-defaults-mode-node": "3.272.0",
+                "@aws-sdk/util-endpoints": "3.272.0",
+                "@aws-sdk/util-retry": "3.272.0",
+                "@aws-sdk/util-user-agent-browser": "3.272.0",
+                "@aws-sdk/util-user-agent-node": "3.272.0",
+                "@aws-sdk/util-utf8": "3.254.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sts": {
+            "version": "3.272.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.272.0.tgz",
+            "integrity": "sha512-kigxCxURp3WupufGaL/LABMb7UQfzAQkKcj9royizL3ItJ0vw5kW/JFrPje5IW1mfLgdPF7PI9ShOjE0fCLTqA==",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "3.0.0",
+                "@aws-crypto/sha256-js": "3.0.0",
+                "@aws-sdk/config-resolver": "3.272.0",
+                "@aws-sdk/credential-provider-node": "3.272.0",
+                "@aws-sdk/fetch-http-handler": "3.272.0",
+                "@aws-sdk/hash-node": "3.272.0",
+                "@aws-sdk/invalid-dependency": "3.272.0",
+                "@aws-sdk/middleware-content-length": "3.272.0",
+                "@aws-sdk/middleware-endpoint": "3.272.0",
+                "@aws-sdk/middleware-host-header": "3.272.0",
+                "@aws-sdk/middleware-logger": "3.272.0",
+                "@aws-sdk/middleware-recursion-detection": "3.272.0",
+                "@aws-sdk/middleware-retry": "3.272.0",
+                "@aws-sdk/middleware-sdk-sts": "3.272.0",
+                "@aws-sdk/middleware-serde": "3.272.0",
+                "@aws-sdk/middleware-signing": "3.272.0",
+                "@aws-sdk/middleware-stack": "3.272.0",
+                "@aws-sdk/middleware-user-agent": "3.272.0",
+                "@aws-sdk/node-config-provider": "3.272.0",
+                "@aws-sdk/node-http-handler": "3.272.0",
+                "@aws-sdk/protocol-http": "3.272.0",
+                "@aws-sdk/smithy-client": "3.272.0",
+                "@aws-sdk/types": "3.272.0",
+                "@aws-sdk/url-parser": "3.272.0",
+                "@aws-sdk/util-base64": "3.208.0",
+                "@aws-sdk/util-body-length-browser": "3.188.0",
+                "@aws-sdk/util-body-length-node": "3.208.0",
+                "@aws-sdk/util-defaults-mode-browser": "3.272.0",
+                "@aws-sdk/util-defaults-mode-node": "3.272.0",
+                "@aws-sdk/util-endpoints": "3.272.0",
+                "@aws-sdk/util-retry": "3.272.0",
+                "@aws-sdk/util-user-agent-browser": "3.272.0",
+                "@aws-sdk/util-user-agent-node": "3.272.0",
+                "@aws-sdk/util-utf8": "3.254.0",
+                "fast-xml-parser": "4.0.11",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/config-resolver": {
+            "version": "3.272.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.272.0.tgz",
+            "integrity": "sha512-Dr4CffRVNsOp3LRNdpvcH6XuSgXOSLblWliCy/5I86cNl567KVMxujVx6uPrdTXYs2h1rt3MNl6jQGnAiJeTbw==",
+            "dependencies": {
+                "@aws-sdk/signature-v4": "3.272.0",
+                "@aws-sdk/types": "3.272.0",
+                "@aws-sdk/util-config-provider": "3.208.0",
+                "@aws-sdk/util-middleware": "3.272.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-cognito-identity": {
+            "version": "3.272.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.272.0.tgz",
+            "integrity": "sha512-rVx0rtQjbiYCM0nah2rB/2ut2YJYPpRr1AbW/Hd4r/PI+yiusrmXAwuT4HIW2yr34zsQMPi1jZ3WHN9Rn9mzlg==",
+            "dependencies": {
+                "@aws-sdk/client-cognito-identity": "3.272.0",
+                "@aws-sdk/property-provider": "3.272.0",
+                "@aws-sdk/types": "3.272.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-env": {
+            "version": "3.272.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.272.0.tgz",
+            "integrity": "sha512-QI65NbLnKLYHyTYhXaaUrq6eVsCCrMUb05WDA7+TJkWkjXesovpjc8vUKgFiLSxmgKmb2uOhHNcDyObKMrYQFw==",
+            "dependencies": {
+                "@aws-sdk/property-provider": "3.272.0",
+                "@aws-sdk/types": "3.272.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-imds": {
+            "version": "3.272.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.272.0.tgz",
+            "integrity": "sha512-wwAfVY1jTFQEfxVfdYD5r5ieYGl+0g4nhekVxNMqE8E1JeRDd18OqiwAflzpgBIqxfqvCUkf+vl5JYyacMkNAQ==",
+            "dependencies": {
+                "@aws-sdk/node-config-provider": "3.272.0",
+                "@aws-sdk/property-provider": "3.272.0",
+                "@aws-sdk/types": "3.272.0",
+                "@aws-sdk/url-parser": "3.272.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-ini": {
+            "version": "3.272.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.272.0.tgz",
+            "integrity": "sha512-iE3CDzK5NcupHYjfYjBdY1JCy8NLEoRUsboEjG0i0gy3S3jVpDeVHX1dLVcL/slBFj6GiM7SoNV/UfKnJf3Gaw==",
+            "dependencies": {
+                "@aws-sdk/credential-provider-env": "3.272.0",
+                "@aws-sdk/credential-provider-imds": "3.272.0",
+                "@aws-sdk/credential-provider-process": "3.272.0",
+                "@aws-sdk/credential-provider-sso": "3.272.0",
+                "@aws-sdk/credential-provider-web-identity": "3.272.0",
+                "@aws-sdk/property-provider": "3.272.0",
+                "@aws-sdk/shared-ini-file-loader": "3.272.0",
+                "@aws-sdk/types": "3.272.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-node": {
+            "version": "3.272.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.272.0.tgz",
+            "integrity": "sha512-FI8uvwM1IxiRSvbkdKv8DZG5vxU3ezaseTaB1fHWTxEUFb0pWIoHX9oeOKer9Fj31SOZTCNAaYFURbSRuZlm/w==",
+            "dependencies": {
+                "@aws-sdk/credential-provider-env": "3.272.0",
+                "@aws-sdk/credential-provider-imds": "3.272.0",
+                "@aws-sdk/credential-provider-ini": "3.272.0",
+                "@aws-sdk/credential-provider-process": "3.272.0",
+                "@aws-sdk/credential-provider-sso": "3.272.0",
+                "@aws-sdk/credential-provider-web-identity": "3.272.0",
+                "@aws-sdk/property-provider": "3.272.0",
+                "@aws-sdk/shared-ini-file-loader": "3.272.0",
+                "@aws-sdk/types": "3.272.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-process": {
+            "version": "3.272.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.272.0.tgz",
+            "integrity": "sha512-hiCAjWWm2PeBFp5cjkxqyam/XADjiS+e7GzwC34TbZn3LisS0uoweLojj9tD11NnnUhyhbLteUvu5+rotOLwrg==",
+            "dependencies": {
+                "@aws-sdk/property-provider": "3.272.0",
+                "@aws-sdk/shared-ini-file-loader": "3.272.0",
+                "@aws-sdk/types": "3.272.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-sso": {
+            "version": "3.272.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.272.0.tgz",
+            "integrity": "sha512-hwYaulyiU/7chKKFecxCeo0ls6Dxs7h+5EtoYcJJGvfpvCncyOZF35t00OAsCd3Wo7HkhhgfpGdb6dmvCNQAZQ==",
+            "dependencies": {
+                "@aws-sdk/client-sso": "3.272.0",
+                "@aws-sdk/property-provider": "3.272.0",
+                "@aws-sdk/shared-ini-file-loader": "3.272.0",
+                "@aws-sdk/token-providers": "3.272.0",
+                "@aws-sdk/types": "3.272.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-web-identity": {
+            "version": "3.272.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.272.0.tgz",
+            "integrity": "sha512-ImrHMkcgneGa/HadHAQXPwOrX26sAKuB8qlMxZF/ZCM2B55u8deY+ZVkVuraeKb7YsahMGehPFOfRAF6mvFI5Q==",
+            "dependencies": {
+                "@aws-sdk/property-provider": "3.272.0",
+                "@aws-sdk/types": "3.272.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers": {
+            "version": "3.272.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.272.0.tgz",
+            "integrity": "sha512-ucd6Xq6aBMf+nM4uz5zkjL11mwaE5BV1Q4hkulaGu2v1dRA8n6zhLJk/sb4hOJ7leelqMJMErlbQ2T3MkYvlJQ==",
+            "dependencies": {
+                "@aws-sdk/client-cognito-identity": "3.272.0",
+                "@aws-sdk/client-sso": "3.272.0",
+                "@aws-sdk/client-sts": "3.272.0",
+                "@aws-sdk/credential-provider-cognito-identity": "3.272.0",
+                "@aws-sdk/credential-provider-env": "3.272.0",
+                "@aws-sdk/credential-provider-imds": "3.272.0",
+                "@aws-sdk/credential-provider-ini": "3.272.0",
+                "@aws-sdk/credential-provider-node": "3.272.0",
+                "@aws-sdk/credential-provider-process": "3.272.0",
+                "@aws-sdk/credential-provider-sso": "3.272.0",
+                "@aws-sdk/credential-provider-web-identity": "3.272.0",
+                "@aws-sdk/property-provider": "3.272.0",
+                "@aws-sdk/shared-ini-file-loader": "3.272.0",
+                "@aws-sdk/types": "3.272.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/eventstream-codec": {
+            "version": "3.272.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-codec/-/eventstream-codec-3.272.0.tgz",
+            "integrity": "sha512-HYMzglDnqUhvx3u9MdzZ/OjLuavaaH9zF9XMXRuv7bdsN9AAi3/0he0FEx84ZXNXSAZCebLwXJYf0ZrN6g37QA==",
+            "dependencies": {
+                "@aws-crypto/crc32": "3.0.0",
+                "@aws-sdk/types": "3.272.0",
+                "@aws-sdk/util-hex-encoding": "3.201.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "node_modules/@aws-sdk/eventstream-serde-browser": {
+            "version": "3.272.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-3.272.0.tgz",
+            "integrity": "sha512-mE1+mevS+KVKpnTLi5FytsBwAK1kWZ92ERtAiElp58SKE1OpfSg8lEY8VI6JKGlueN540Qq3LeIgA2/HJOcK/w==",
+            "dependencies": {
+                "@aws-sdk/eventstream-serde-universal": "3.272.0",
+                "@aws-sdk/types": "3.272.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/eventstream-serde-config-resolver": {
+            "version": "3.272.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.272.0.tgz",
+            "integrity": "sha512-e47BhGBvx+me53cvYx+47ml5KNDj7XoTth80krHlyLrimFELE1ij4tHSKR/XzilKKH1uIWmJQdlAi29129ZX5w==",
+            "dependencies": {
+                "@aws-sdk/types": "3.272.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/eventstream-serde-node": {
+            "version": "3.272.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-node/-/eventstream-serde-node-3.272.0.tgz",
+            "integrity": "sha512-uto8y4FoZugWnczM1TKwv6oV2Po2Jgrp+W1Ws3baRQ4Lan+QpFx3Tps1N5rNzQ+7Uz0xT1BhbSNPAkKs22/jtg==",
+            "dependencies": {
+                "@aws-sdk/eventstream-serde-universal": "3.272.0",
+                "@aws-sdk/types": "3.272.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/eventstream-serde-universal": {
+            "version": "3.272.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-3.272.0.tgz",
+            "integrity": "sha512-E9jlt8tzDcEMoNlgv3+01jGPJPHmbmw2NsajZhB4axVMpEy247JV6qvCZe+5R+EGy96t0pfsO2naViEB4Va47g==",
+            "dependencies": {
+                "@aws-sdk/eventstream-codec": "3.272.0",
+                "@aws-sdk/types": "3.272.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/fetch-http-handler": {
+            "version": "3.272.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.272.0.tgz",
+            "integrity": "sha512-1Qhm9e0RbS1Xf4CZqUbQyUMkDLd7GrsRXWIvm9b86/vgeV8/WnjO3CMue9D51nYgcyQORhYXv6uVjAYCWbUExA==",
+            "dependencies": {
+                "@aws-sdk/protocol-http": "3.272.0",
+                "@aws-sdk/querystring-builder": "3.272.0",
+                "@aws-sdk/types": "3.272.0",
+                "@aws-sdk/util-base64": "3.208.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "node_modules/@aws-sdk/hash-blob-browser": {
+            "version": "3.272.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/hash-blob-browser/-/hash-blob-browser-3.272.0.tgz",
+            "integrity": "sha512-IRCIMG42fXcdD92C8Sb0CQI8D/msxDwHGAIqP94iGhVEnKX2egyx5J8lmPY4gEky5UzyMMaH7cayBv89ZMEBmQ==",
+            "dependencies": {
+                "@aws-sdk/chunked-blob-reader": "3.188.0",
+                "@aws-sdk/chunked-blob-reader-native": "3.208.0",
+                "@aws-sdk/types": "3.272.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "node_modules/@aws-sdk/hash-node": {
+            "version": "3.272.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.272.0.tgz",
+            "integrity": "sha512-40dwND+iAm3VtPHPZu7/+CIdVJFk2s0cWZt1lOiMPMSXycSYJ45wMk7Lly3uoqRx0uWfFK5iT2OCv+fJi5jTng==",
+            "dependencies": {
+                "@aws-sdk/types": "3.272.0",
+                "@aws-sdk/util-buffer-from": "3.208.0",
+                "@aws-sdk/util-utf8": "3.254.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/hash-stream-node": {
+            "version": "3.272.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/hash-stream-node/-/hash-stream-node-3.272.0.tgz",
+            "integrity": "sha512-mWwQWdfVYoR6PXRLkHP6pC1cghZMg0ULuOAm70EtTO2YXiyLlMIDb+VD4RRbjh3hNkzh+y/W47wSUJthGBM1kg==",
+            "dependencies": {
+                "@aws-sdk/types": "3.272.0",
+                "@aws-sdk/util-utf8": "3.254.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/invalid-dependency": {
+            "version": "3.272.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.272.0.tgz",
+            "integrity": "sha512-ysW6wbjl1Y78txHUQ/Tldj2Rg1BI7rpMO9B9xAF6yAX3mQ7t6SUPQG/ewOGvH2208NBIl3qP5e/hDf0Q6r/1iw==",
+            "dependencies": {
+                "@aws-sdk/types": "3.272.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "node_modules/@aws-sdk/is-array-buffer": {
+            "version": "3.201.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
+            "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
+            "dependencies": {
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/md5-js": {
+            "version": "3.272.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.272.0.tgz",
+            "integrity": "sha512-/GK32mgAarhn/F0xCeBKbYfLRof3tOCNrg8mAGNz9Di8E1/qMOnX/OXUGag0lsvNZ6DTjdjln29t4e8iKmOVqA==",
+            "dependencies": {
+                "@aws-sdk/types": "3.272.0",
+                "@aws-sdk/util-utf8": "3.254.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-bucket-endpoint": {
+            "version": "3.272.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.272.0.tgz",
+            "integrity": "sha512-523T6JXfjsY9uSgMusa6myCccRv2TWyUSjzMx/0aUHfHRacJSunfPtSNX1kfYxXWn/ByWhaieHFBPehVI6wg1A==",
+            "dependencies": {
+                "@aws-sdk/protocol-http": "3.272.0",
+                "@aws-sdk/types": "3.272.0",
+                "@aws-sdk/util-arn-parser": "3.208.0",
+                "@aws-sdk/util-config-provider": "3.208.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-content-length": {
+            "version": "3.272.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.272.0.tgz",
+            "integrity": "sha512-sAbDZSTNmLX+UTGwlUHJBWy0QGQkiClpHwVFXACon+aG0ySLNeRKEVYs6NCPYldw4cj6hveLUn50cX44ukHErw==",
+            "dependencies": {
+                "@aws-sdk/protocol-http": "3.272.0",
+                "@aws-sdk/types": "3.272.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-endpoint": {
+            "version": "3.272.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.272.0.tgz",
+            "integrity": "sha512-Dk3JVjj7SxxoUKv3xGiOeBksvPtFhTDrVW75XJ98Ymv8gJH5L1sq4hIeJAHRKogGiRFq2J73mnZSlM9FVXEylg==",
+            "dependencies": {
+                "@aws-sdk/middleware-serde": "3.272.0",
+                "@aws-sdk/protocol-http": "3.272.0",
+                "@aws-sdk/signature-v4": "3.272.0",
+                "@aws-sdk/types": "3.272.0",
+                "@aws-sdk/url-parser": "3.272.0",
+                "@aws-sdk/util-config-provider": "3.208.0",
+                "@aws-sdk/util-middleware": "3.272.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-expect-continue": {
+            "version": "3.272.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.272.0.tgz",
+            "integrity": "sha512-TNx61LCZUKp/yZqcb38qb4tU3lbhKaI9zn2FQ+fpKzUSTI3H6E5aw42wHaq2LEacYlyK3b5Wg1R0sKR+vsUutw==",
+            "dependencies": {
+                "@aws-sdk/protocol-http": "3.272.0",
+                "@aws-sdk/types": "3.272.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-flexible-checksums": {
+            "version": "3.272.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.272.0.tgz",
+            "integrity": "sha512-dc/tMiYM4wTZpjXf2PSQCFD4SQI5wyVwY5SoBgcB3W2XLq1SzXahiDnnUSn2EzDTKPIrmQmYyDFRpFEPo0sP/g==",
+            "dependencies": {
+                "@aws-crypto/crc32": "3.0.0",
+                "@aws-crypto/crc32c": "3.0.0",
+                "@aws-sdk/is-array-buffer": "3.201.0",
+                "@aws-sdk/protocol-http": "3.272.0",
+                "@aws-sdk/types": "3.272.0",
+                "@aws-sdk/util-utf8": "3.254.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-host-header": {
+            "version": "3.272.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.272.0.tgz",
+            "integrity": "sha512-Q8K7bMMFZnioUXpxn57HIt4p+I63XaNAawMLIZ5B4F2piyukbQeM9q2XVKMGwqLvijHR8CyP5nHrtKqVuINogQ==",
+            "dependencies": {
+                "@aws-sdk/protocol-http": "3.272.0",
+                "@aws-sdk/types": "3.272.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-location-constraint": {
+            "version": "3.272.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.272.0.tgz",
+            "integrity": "sha512-tROQ1DM9djxfXmXPTT0XietrUt6y6QEHShPI9rQMstjXYiaHBVXRveuRLcLAKwl4nXIrgmnIU7ygyj2ZyD8gcA==",
+            "dependencies": {
+                "@aws-sdk/types": "3.272.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-logger": {
+            "version": "3.272.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.272.0.tgz",
+            "integrity": "sha512-u2SQ0hWrFwxbxxYMG5uMEgf01pQY5jauK/LYWgGIvuCmFgiyRQQP3oN7kkmsxnS9MWmNmhbyQguX2NY02s5e9w==",
+            "dependencies": {
+                "@aws-sdk/types": "3.272.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-recursion-detection": {
+            "version": "3.272.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.272.0.tgz",
+            "integrity": "sha512-Gp/eKWeUWVNiiBdmUM2qLkBv+VLSJKoWAO+aKmyxxwjjmWhE0FrfA1NQ1a3g+NGMhRbAfQdaYswRAKsul70ISg==",
+            "dependencies": {
+                "@aws-sdk/protocol-http": "3.272.0",
+                "@aws-sdk/types": "3.272.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-retry": {
+            "version": "3.272.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.272.0.tgz",
+            "integrity": "sha512-pCGvHM7C76VbO/dFerH+Vwf7tGv7j+e+eGrvhQ35mRghCtfIou/WMfTZlD1TNee93crrAQQVZKjtW3dMB3WCzg==",
+            "dependencies": {
+                "@aws-sdk/protocol-http": "3.272.0",
+                "@aws-sdk/service-error-classification": "3.272.0",
+                "@aws-sdk/types": "3.272.0",
+                "@aws-sdk/util-middleware": "3.272.0",
+                "@aws-sdk/util-retry": "3.272.0",
+                "tslib": "^2.3.1",
+                "uuid": "^8.3.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-retry/node_modules/uuid": {
+            "version": "8.3.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+            "bin": {
+                "uuid": "dist/bin/uuid"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-sdk-s3": {
+            "version": "3.272.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.272.0.tgz",
+            "integrity": "sha512-uMvoLePkyP54b9BckMELlDnFh0SGPAfTkBwiH/FC79K7noGLA5A4KgqKObtB9LPYHkPfm1WLqIgdaE6gS1BlFQ==",
+            "dependencies": {
+                "@aws-sdk/protocol-http": "3.272.0",
+                "@aws-sdk/types": "3.272.0",
+                "@aws-sdk/util-arn-parser": "3.208.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-sdk-sts": {
+            "version": "3.272.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.272.0.tgz",
+            "integrity": "sha512-VvYPg7LrDIjUOWueSzo2wBzcNG7dw+cmzV6zAKaLxf0RC5jeAP4hE0OzDiiZfDrjNghEzgq/V+0NO+LewqYL9Q==",
+            "dependencies": {
+                "@aws-sdk/middleware-signing": "3.272.0",
+                "@aws-sdk/property-provider": "3.272.0",
+                "@aws-sdk/protocol-http": "3.272.0",
+                "@aws-sdk/signature-v4": "3.272.0",
+                "@aws-sdk/types": "3.272.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-serde": {
+            "version": "3.272.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.272.0.tgz",
+            "integrity": "sha512-kW1uOxgPSwtXPB5rm3QLdWomu42lkYpQL94tM1BjyFOWmBLO2lQhk5a7Dw6HkTozT9a+vxtscLChRa6KZe61Hw==",
+            "dependencies": {
+                "@aws-sdk/types": "3.272.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-signing": {
+            "version": "3.272.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.272.0.tgz",
+            "integrity": "sha512-4LChFK4VAR91X+dupqM8fQqYhFGE0G4Bf9rQlVTgGSbi2KUOmpqXzH0/WKE228nKuEhmH8+Qd2VPSAE2JcyAUA==",
+            "dependencies": {
+                "@aws-sdk/property-provider": "3.272.0",
+                "@aws-sdk/protocol-http": "3.272.0",
+                "@aws-sdk/signature-v4": "3.272.0",
+                "@aws-sdk/types": "3.272.0",
+                "@aws-sdk/util-middleware": "3.272.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-ssec": {
+            "version": "3.272.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.272.0.tgz",
+            "integrity": "sha512-WDPcNPkscTmJUzdAvfx8p+YuUn2YR9ocmZA7yYUJ5kA94MyGH6Rbjp8tleWwQvah/HweeCQrYUzJk9wsH64LPA==",
+            "dependencies": {
+                "@aws-sdk/types": "3.272.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-stack": {
+            "version": "3.272.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.272.0.tgz",
+            "integrity": "sha512-jhwhknnPBGhfXAGV5GXUWfEhDFoP/DN8MPCO2yC5OAxyp6oVJ8lTPLkZYMTW5VL0c0eG44dXpF4Ib01V+PlDrQ==",
+            "dependencies": {
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-user-agent": {
+            "version": "3.272.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.272.0.tgz",
+            "integrity": "sha512-Qy7/0fsDJxY5l0bEk7WKDfqb4Os/sCAgFR2zEvrhDtbkhYPf72ysvg/nRUTncmCbo8tOok4SJii2myk8KMfjjw==",
+            "dependencies": {
+                "@aws-sdk/protocol-http": "3.272.0",
+                "@aws-sdk/types": "3.272.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/node-config-provider": {
+            "version": "3.272.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.272.0.tgz",
+            "integrity": "sha512-YYCIBh9g1EQo7hm2l22HX5Yr9RoPQ2RCvhzKvF1n1e8t1QH4iObQrYUtqHG4khcm64Cft8C5MwZmgzHbya5Z6Q==",
+            "dependencies": {
+                "@aws-sdk/property-provider": "3.272.0",
+                "@aws-sdk/shared-ini-file-loader": "3.272.0",
+                "@aws-sdk/types": "3.272.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/node-http-handler": {
+            "version": "3.272.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.272.0.tgz",
+            "integrity": "sha512-VrW9PjhhngeyYp4yGYPe5S0vgZH6NwU3Po9xAgayUeE37Inr7LS1YteFMHdpgsUUeNXnh7d06CXqHo1XjtqOKA==",
+            "dependencies": {
+                "@aws-sdk/abort-controller": "3.272.0",
+                "@aws-sdk/protocol-http": "3.272.0",
+                "@aws-sdk/querystring-builder": "3.272.0",
+                "@aws-sdk/types": "3.272.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/property-provider": {
+            "version": "3.272.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.272.0.tgz",
+            "integrity": "sha512-V1pZTaH5eqpAt8O8CzbItHhOtzIfFuWymvwZFkAtwKuaHpnl7jjrTouV482zoq8AD/fF+VVSshwBKYA7bhidIw==",
+            "dependencies": {
+                "@aws-sdk/types": "3.272.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/protocol-http": {
+            "version": "3.272.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.272.0.tgz",
+            "integrity": "sha512-4JQ54v5Yn08jspNDeHo45CaSn1CvTJqS1Ywgr79eU6jBExtguOWv6LNtwVSBD9X37v88iqaxt8iu1Z3pZZAJeg==",
+            "dependencies": {
+                "@aws-sdk/types": "3.272.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/querystring-builder": {
+            "version": "3.272.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.272.0.tgz",
+            "integrity": "sha512-ndo++7GkdCj5tBXE6rGcITpSpZS4PfyV38wntGYAlj9liL1omk3bLZRY6uzqqkJpVHqbg2fD7O2qHNItzZgqhw==",
+            "dependencies": {
+                "@aws-sdk/types": "3.272.0",
+                "@aws-sdk/util-uri-escape": "3.201.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/querystring-parser": {
+            "version": "3.272.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.272.0.tgz",
+            "integrity": "sha512-5oS4/9n6N1LZW9tI3qq/0GnCuWoOXRgcHVB+AJLRBvDbEe+GI+C/xK1tKLsfpDNgsQJHc4IPQoIt4megyZ/1+A==",
+            "dependencies": {
+                "@aws-sdk/types": "3.272.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/service-error-classification": {
+            "version": "3.272.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.272.0.tgz",
+            "integrity": "sha512-REoltM1LK9byyIufLqx9znhSolPcHQgVHIA2S0zu5sdt5qER4OubkLAXuo4MBbisUTmh8VOOvIyUb5ijZCXq1w==",
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/shared-ini-file-loader": {
+            "version": "3.272.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.272.0.tgz",
+            "integrity": "sha512-lzFPohp5sy2XvwFjZIzLVCRpC0i5cwBiaXmFzXYQZJm6FSCszHO4ax+m9yrtlyVFF/2YPWl+/bzNthy4aJtseA==",
+            "dependencies": {
+                "@aws-sdk/types": "3.272.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/signature-v4": {
+            "version": "3.272.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.272.0.tgz",
+            "integrity": "sha512-pWxnHG1NqJWMwlhJ6NHNiUikOL00DHROmxah6krJPMPq4I3am2KY2Rs/8ouWhnEXKaHAv4EQhSALJ+7Mq5S4/A==",
+            "dependencies": {
+                "@aws-sdk/is-array-buffer": "3.201.0",
+                "@aws-sdk/types": "3.272.0",
+                "@aws-sdk/util-hex-encoding": "3.201.0",
+                "@aws-sdk/util-middleware": "3.272.0",
+                "@aws-sdk/util-uri-escape": "3.201.0",
+                "@aws-sdk/util-utf8": "3.254.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/signature-v4-multi-region": {
+            "version": "3.272.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.272.0.tgz",
+            "integrity": "sha512-nir/ICA3saE303tS+DuJ803Uocn/d3hOpOl5DqI9RDjaZxbTXwv9uHP+by8sdyyfwCE8TFaYWoiSW5rLI+Qt0g==",
+            "dependencies": {
+                "@aws-sdk/protocol-http": "3.272.0",
+                "@aws-sdk/signature-v4": "3.272.0",
+                "@aws-sdk/types": "3.272.0",
+                "@aws-sdk/util-arn-parser": "3.208.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "@aws-sdk/signature-v4-crt": "^3.118.0"
+            },
+            "peerDependenciesMeta": {
+                "@aws-sdk/signature-v4-crt": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@aws-sdk/smithy-client": {
+            "version": "3.272.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.272.0.tgz",
+            "integrity": "sha512-pvdleJ3kaRvyRw2pIZnqL85ZlWBOZrPKmR9I69GCvlyrfdjRBhbSjIEZ+sdhZudw0vdHxq25AGoLUXhofVLf5Q==",
+            "dependencies": {
+                "@aws-sdk/middleware-stack": "3.272.0",
+                "@aws-sdk/types": "3.272.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/token-providers": {
+            "version": "3.272.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.272.0.tgz",
+            "integrity": "sha512-0GISJ4IKN2rXvbSddB775VjBGSKhYIGQnAdMqbvxi9LB6pSvVxcH9aIL28G0spiuL+dy3yGQZ8RlJPAyP9JW9A==",
+            "dependencies": {
+                "@aws-sdk/client-sso-oidc": "3.272.0",
+                "@aws-sdk/property-provider": "3.272.0",
+                "@aws-sdk/shared-ini-file-loader": "3.272.0",
+                "@aws-sdk/types": "3.272.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/types": {
+            "version": "3.272.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.272.0.tgz",
+            "integrity": "sha512-MmmL6vxMGP5Bsi+4wRx4mxYlU/LX6M0noOXrDh/x5FfG7/4ZOar/nDxqDadhJtNM88cuWVHZWY59P54JzkGWmA==",
+            "dependencies": {
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/url-parser": {
+            "version": "3.272.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.272.0.tgz",
+            "integrity": "sha512-vX/Tx02PlnQ/Kgtf5TnrNDHPNbY+amLZjW0Z1d9vzAvSZhQ4i9Y18yxoRDIaDTCNVRDjdhV8iuctW+05PB5JtQ==",
+            "dependencies": {
+                "@aws-sdk/querystring-parser": "3.272.0",
+                "@aws-sdk/types": "3.272.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "node_modules/@aws-sdk/util-arn-parser": {
+            "version": "3.208.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.208.0.tgz",
+            "integrity": "sha512-QV4af+kscova9dv4VuHOgH8wEr/IIYHDGcnyVtkUEqahCejWr1Kuk+SBK0xMwnZY5LSycOtQ8aeqHOn9qOjZtA==",
+            "dependencies": {
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-base64": {
+            "version": "3.208.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.208.0.tgz",
+            "integrity": "sha512-PQniZph5A6N7uuEOQi+1hnMz/FSOK/8kMFyFO+4DgA1dZ5pcKcn5wiFwHkcTb/BsgVqQa3Jx0VHNnvhlS8JyTg==",
+            "dependencies": {
+                "@aws-sdk/util-buffer-from": "3.208.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-body-length-browser": {
+            "version": "3.188.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
+            "integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
+            "dependencies": {
+                "tslib": "^2.3.1"
+            }
+        },
+        "node_modules/@aws-sdk/util-body-length-node": {
+            "version": "3.208.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.208.0.tgz",
+            "integrity": "sha512-3zj50e5g7t/MQf53SsuuSf0hEELzMtD8RX8C76f12OSRo2Bca4FLLYHe0TZbxcfQHom8/hOaeZEyTyMogMglqg==",
+            "dependencies": {
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-buffer-from": {
+            "version": "3.208.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
+            "integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
+            "dependencies": {
+                "@aws-sdk/is-array-buffer": "3.201.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-config-provider": {
+            "version": "3.208.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
+            "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
+            "dependencies": {
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-defaults-mode-browser": {
+            "version": "3.272.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.272.0.tgz",
+            "integrity": "sha512-W8ZVJSZRuUBg8l0JEZzUc+9fKlthVp/cdE+pFeF8ArhZelOLCiaeCrMaZAeJusaFzIpa6cmOYQAjtSMVyrwRtg==",
+            "dependencies": {
+                "@aws-sdk/property-provider": "3.272.0",
+                "@aws-sdk/types": "3.272.0",
+                "bowser": "^2.11.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-defaults-mode-node": {
+            "version": "3.272.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.272.0.tgz",
+            "integrity": "sha512-U0NTcbMw6KFk7uz/avBmfxQSTREEiX6JDMH68oN/3ux4AICd2I4jHyxnloSWGuiER1FxZf1dEJ8ZTwy8Ibl21Q==",
+            "dependencies": {
+                "@aws-sdk/config-resolver": "3.272.0",
+                "@aws-sdk/credential-provider-imds": "3.272.0",
+                "@aws-sdk/node-config-provider": "3.272.0",
+                "@aws-sdk/property-provider": "3.272.0",
+                "@aws-sdk/types": "3.272.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-endpoints": {
+            "version": "3.272.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.272.0.tgz",
+            "integrity": "sha512-c4MPUaJt2G6gGpoiwIOqDfUa98c1J63RpYvf/spQEKOtC/tF5Gfqlxuq8FnAl5lHnrqj1B9ZXLLxFhHtDR0IiQ==",
+            "dependencies": {
+                "@aws-sdk/types": "3.272.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-hex-encoding": {
+            "version": "3.201.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
+            "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
+            "dependencies": {
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-locate-window": {
+            "version": "3.208.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.208.0.tgz",
+            "integrity": "sha512-iua1A2+P7JJEDHVgvXrRJSvsnzG7stYSGQnBVphIUlemwl6nN5D+QrgbjECtrbxRz8asYFHSzhdhECqN+tFiBg==",
+            "dependencies": {
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-middleware": {
+            "version": "3.272.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.272.0.tgz",
+            "integrity": "sha512-Abw8m30arbwxqmeMMha5J11ESpHUNmCeSqSzE8/C4B8jZQtHY4kq7f+upzcNIQ11lsd+uzBEzNG3+dDRi0XOJQ==",
+            "dependencies": {
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-retry": {
+            "version": "3.272.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.272.0.tgz",
+            "integrity": "sha512-Ngha5414LR4gRHURVKC9ZYXsEJhMkm+SJ+44wlzOhavglfdcKKPUsibz5cKY1jpUV7oKECwaxHWpBB8r6h+hOg==",
+            "dependencies": {
+                "@aws-sdk/service-error-classification": "3.272.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">= 14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-stream-browser": {
+            "version": "3.272.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-browser/-/util-stream-browser-3.272.0.tgz",
+            "integrity": "sha512-vD514YffKxBjV/erjUNgkXcb/mzXAz3uk/KUFMXsodo3cA4Z8WxL4P0p1O09FVuJlNa0gZ8mhFPNzNOekh31GA==",
+            "dependencies": {
+                "@aws-sdk/fetch-http-handler": "3.272.0",
+                "@aws-sdk/types": "3.272.0",
+                "@aws-sdk/util-base64": "3.208.0",
+                "@aws-sdk/util-hex-encoding": "3.201.0",
+                "@aws-sdk/util-utf8": "3.254.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "node_modules/@aws-sdk/util-stream-node": {
+            "version": "3.272.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-node/-/util-stream-node-3.272.0.tgz",
+            "integrity": "sha512-s7dGeM1ImzihqBKgrpaeZokLnPUk3H4Et5oiM+t+TpRxotXTecJPyuD0p76HRgO8KSXfVT5Nxw/FoHXqj1fiMg==",
+            "dependencies": {
+                "@aws-sdk/node-http-handler": "3.272.0",
+                "@aws-sdk/types": "3.272.0",
+                "@aws-sdk/util-buffer-from": "3.208.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-uri-escape": {
+            "version": "3.201.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
+            "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
+            "dependencies": {
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-user-agent-browser": {
+            "version": "3.272.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.272.0.tgz",
+            "integrity": "sha512-Lp5QX5bH6uuwBlIdr7w7OAcAI50ttyskb++yUr9i+SPvj6RI2dsfIBaK4mDg1qUdM5LeUdvIyqwj3XHjFKAAvA==",
+            "dependencies": {
+                "@aws-sdk/types": "3.272.0",
+                "bowser": "^2.11.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "node_modules/@aws-sdk/util-user-agent-node": {
+            "version": "3.272.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.272.0.tgz",
+            "integrity": "sha512-ljK+R3l+Q1LIHrcR+Knhk0rmcSkfFadZ8V+crEGpABf/QUQRg7NkZMsoe814tfBO5F7tMxo8wwwSdaVNNHtoRA==",
+            "dependencies": {
+                "@aws-sdk/node-config-provider": "3.272.0",
+                "@aws-sdk/types": "3.272.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "aws-crt": ">=1.0.0"
+            },
+            "peerDependenciesMeta": {
+                "aws-crt": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@aws-sdk/util-utf8": {
+            "version": "3.254.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8/-/util-utf8-3.254.0.tgz",
+            "integrity": "sha512-14Kso/eIt5/qfIBmhEL9L1IfyUqswjSTqO2mY7KOzUZ9SZbwn3rpxmtkhmATkRjD7XIlLKaxBkI7tU9Zjzj8Kw==",
+            "dependencies": {
+                "@aws-sdk/util-buffer-from": "3.208.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-utf8-browser": {
+            "version": "3.259.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
+            "integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
+            "dependencies": {
+                "tslib": "^2.3.1"
+            }
+        },
+        "node_modules/@aws-sdk/util-waiter": {
+            "version": "3.272.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.272.0.tgz",
+            "integrity": "sha512-N25/XsJ2wkPh1EgkFyb/GRgfHDityScfD49Hk1AwJWpfetzgkcEtWdeW4IuPymXlSKhrm5L+SBw49USxo9kBag==",
+            "dependencies": {
+                "@aws-sdk/abort-controller": "3.272.0",
+                "@aws-sdk/types": "3.272.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/xml-builder": {
+            "version": "3.201.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.201.0.tgz",
+            "integrity": "sha512-brRdB1wwMgjWEnOQsv7zSUhIQuh7DEicrfslAqHop4S4FtSI3GQAShpQqgOpMTNFYcpaWKmE/Y1MJmNY7xLCnw==",
+            "dependencies": {
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
             }
         },
         "node_modules/@babel/code-frame": {
@@ -759,10 +2315,11 @@
             }
         },
         "node_modules/@openaddresses/cfn-config": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/@openaddresses/cfn-config/-/cfn-config-6.3.0.tgz",
-            "integrity": "sha512-pC77rcd54GNP8UMqoy7+e6AV/MFF8BQTb8fVCEtw6MEClTiBdC4YXjN0mFnOpscM1RfO55DDR5Ca2gCo+oKEtA==",
+            "version": "6.4.0",
+            "resolved": "https://registry.npmjs.org/@openaddresses/cfn-config/-/cfn-config-6.4.0.tgz",
+            "integrity": "sha512-XgbIKcm4VsKzZPAljWrBMsPxcCiS7fGqow9UYwitdTDl9ONYBDtchdYo6F7wwY1lhFyuj7pUjLHj5awfmhMzug==",
             "dependencies": {
+                "@openaddresses/s3urls": "^3.3.0",
                 "aws-sdk": "^2.720.0",
                 "cfn-stack-event-stream": "^1.0.1",
                 "colors": "1.4.0",
@@ -773,14 +2330,21 @@
                 "inquirer": "^9.0.0",
                 "json-diff": "^0.9.0",
                 "json-stable-stringify": "1.0.1",
-                "meow": "^11.0.0",
-                "s3urls": "^1.5.2"
+                "meow": "^11.0.0"
             },
             "bin": {
                 "cfn-config": "bin/cfn-config.js"
             },
             "engines": {
-                "node": ">= 16"
+                "node": ">= 18"
+            }
+        },
+        "node_modules/@openaddresses/s3urls": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/@openaddresses/s3urls/-/s3urls-3.3.0.tgz",
+            "integrity": "sha512-WsxFv+CvJgGpRZrwiayH1vLuo95ymiVopYJtZ92fyHotgfmz0TvN7/F5xDKHlDTU8Y7nbv5SzAoGjasOiTm0lQ==",
+            "engines": {
+                "node": ">= 6.10.3"
             }
         },
         "node_modules/@types/debug": {
@@ -1157,6 +2721,11 @@
                     "url": "https://feross.org/support"
                 }
             ]
+        },
+        "node_modules/bowser": {
+            "version": "2.11.0",
+            "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+            "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
         },
         "node_modules/brace-expansion": {
             "version": "1.1.11",
@@ -2425,6 +3994,21 @@
             "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
             "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
             "dev": true
+        },
+        "node_modules/fast-xml-parser": {
+            "version": "4.0.11",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.11.tgz",
+            "integrity": "sha512-4aUg3aNRR/WjQAcpceODG1C3x3lFANXRo8+1biqfieHmg9pyMt7qB4lQV/Ta6sJCTbA5vfD8fnA8S54JATiFUA==",
+            "dependencies": {
+                "strnum": "^1.0.5"
+            },
+            "bin": {
+                "fxparser": "src/cli/cli.js"
+            },
+            "funding": {
+                "type": "paypal",
+                "url": "https://paypal.me/naturalintelligence"
+            }
         },
         "node_modules/fasterror": {
             "version": "1.1.0",
@@ -5649,30 +7233,6 @@
                 "tslib": "^2.1.0"
             }
         },
-        "node_modules/s3signed": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/s3signed/-/s3signed-0.1.0.tgz",
-            "integrity": "sha512-08Jc0+GAaFjXgvl8qQytu6+wVBfcUUyCJDocj5kBUeq9YA+6mAM/6psDNxrg4PVkkLBvAK75mnjlaGckfOtDKA==",
-            "deprecated": "This module is no longer maintained. It is provided as is.",
-            "dependencies": {
-                "aws-sdk": "^2.0.4"
-            },
-            "bin": {
-                "s3signed": "bin/s3signed.js"
-            }
-        },
-        "node_modules/s3urls": {
-            "version": "1.5.2",
-            "resolved": "https://registry.npmjs.org/s3urls/-/s3urls-1.5.2.tgz",
-            "integrity": "sha512-3f4kprxnwAqoiVdR/XFoc997YEt0b6oY1VKrhl+kuWnHaUQ2cVe73TcQaww8geX5FKPuGBHl90xv70q7SlbBew==",
-            "dependencies": {
-                "minimist": "^1.1.0",
-                "s3signed": "^0.1.0"
-            },
-            "bin": {
-                "s3urls": "bin/s3urls.js"
-            }
-        },
         "node_modules/sade": {
             "version": "1.8.1",
             "resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
@@ -5921,6 +7481,11 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
+        },
+        "node_modules/strnum": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+            "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
         },
         "node_modules/supports-color": {
             "version": "9.3.1",

--- a/package.json
+++ b/package.json
@@ -13,10 +13,14 @@
         "deploy": "cli.js"
     },
     "dependencies": {
+        "@aws-sdk/client-cloudformation": "^3.272.0",
+        "@aws-sdk/client-ecr": "^3.272.0",
+        "@aws-sdk/client-s3": "^3.272.0",
+        "@aws-sdk/client-secrets-manager": "^3.272.0",
+        "@aws-sdk/credential-providers": "^3.272.0",
         "@octokit/rest": "^19.0.0",
-        "@openaddresses/cfn-config": "^6.3.0",
+        "@openaddresses/cfn-config": "^6.4.0",
         "ajv": "^8.6.3",
-        "aws-sdk": "^2.656.0",
         "cli-table": "^0.3.1",
         "handlebars": "^4.7.7",
         "inquirer": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     },
     "dependencies": {
         "@aws-sdk/client-cloudformation": "^3.272.0",
+        "@aws-sdk/client-ec2": "^3.272.0",
         "@aws-sdk/client-ecr": "^3.272.0",
         "@aws-sdk/client-s3": "^3.272.0",
         "@aws-sdk/client-secrets-manager": "^3.272.0",


### PR DESCRIPTION
### Context

The V2 API has been deprecated and is printing and irritating message to terminal. This PR removes all top-level instances of aws-sdk in favour of the new V3 API.

Note: this does not remove aws-sdk from lower level dependencies and as such the irritating warning will still be printed until I get around to updating all underlying deps. I've started the process by updating `@openaddresses/s3urls` to typescript & removing the old v2 sdk.