### PR TITLE
Remove: node-fetch

### DIFF
--- a/lib/gh.js
+++ b/lib/gh.js
@@ -1,5 +1,4 @@
 import fs from 'fs';
-import fetch from 'node-fetch';
 
 /**
  * @class

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
     "bin": {
         "deploy": "cli.js"
     },
+    "engines": {
+        "node": ">18"
+    },
     "dependencies": {
         "@aws-sdk/client-cloudformation": "^3.272.0",
         "@aws-sdk/client-ec2": "^3.272.0",
@@ -19,14 +22,12 @@
         "@aws-sdk/client-s3": "^3.272.0",
         "@aws-sdk/client-secrets-manager": "^3.272.0",
         "@aws-sdk/credential-providers": "^3.272.0",
-        "@octokit/rest": "^19.0.0",
         "@openaddresses/cfn-config": "^6.4.0",
         "ajv": "^8.6.3",
         "cli-table": "^0.3.1",
         "handlebars": "^4.7.7",
         "inquirer": "^9.0.0",
         "minimist": "^1.2.5",
-        "node-fetch": "^3.2.3",
         "prompt": "^1.0.0"
     },
     "devDependencies": {


### PR DESCRIPTION
### Context

Now that node 18 supports native fetch, drop the node-fetch dep.