### PR TITLE
fix endless hang if no GH checks

### DIFF
--- a/lib/gh.ts
+++ b/lib/gh.ts
@@ -106,6 +106,12 @@ export default class GH {
             while (Date.now() - startTime < timeout) {
                 const status = await this.status();
                 const checks = status.check_runs ?? [];
+
+                if (checks.length === 0) {
+                    progress.info(`No status checks associated with ${this.context.sha}`)
+                    return;
+                }
+                
                 const completed = checks.filter((check) => check.status === 'completed');
                 const failed = completed.filter((check) => {
                     const conclusion = check.conclusion ?? '';


### PR DESCRIPTION
Noticed that if you are deploy from a branch or a commit that has no checks associated with the Git SHA that the deploy will hang:

<img width="479" height="48" alt="image" src="https://github.com/user-attachments/assets/32cecd89-684b-4bc4-96ee-5a167bb7374c" />

<small>(screenshot taken 10 minutes after the command)</small>


This adds an early exit in cases where no check runs are found at the time of deploy.